### PR TITLE
Remove Node 12 deprecation warnings

### DIFF
--- a/.github/workflows/sync_sites_branch.yml
+++ b/.github/workflows/sync_sites_branch.yml
@@ -4,15 +4,17 @@ on:
   push:
     branches:
       - main
+
 jobs:
   sync-branches:
     runs-on: ubuntu-latest
     name: Syncing branches
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - uses: mtanzi/action-automerge@v1
+        uses: actions/checkout@v3
+      - uses: devmasx/merge-branch@v1.4.0
         with:
-          source: "${{ github.event.repository.default_branch }}"
-          target: "storybook-site"
+          type: now
+          from_branch: ${{ github.event.repository.default_branch }}
+          target_branch: storybook-site
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Update the `sync-sites-branch` GH workflow to remove Node 12 deprecation [warnings](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/). These are the same changes as in the `search-ui-react` [PR](https://github.com/yext/search-ui-react/pull/345) since this workflow is just copied from there. I made an [item](https://yexttest.atlassian.net/browse/SLAP-2507) to move this workflow into the reusable workflows repo so that multiple updates aren't needed for any other changes in the future.

J=SLAP-2468
TEST=manual

See the PR linked above for details.