### PR TITLE
Update the Tailwind Styling for Lexical Content.

### DIFF
--- a/src/components/richText/DefaultStyling.ts
+++ b/src/components/richText/DefaultStyling.ts
@@ -5,22 +5,28 @@ import { EditorThemeClasses } from "lexical";
  * Elements.
  */
 const DefaultNodeStyling: EditorThemeClasses = {
-  paragraph: "mb-2 relative",
+  paragraph: "m-0 mb-2 relative",
   link: "text-blue-500",
   heading: {
-    h1: "text-2xl",
+    h1: "text-2xl font-normal m-0 mb-3 p-0",
+    h2: "text-sm text-gray-600 font-bold m-0 mt-2 p-0 uppercase",
+    h3: "text-xs m-0 uppercase font-bold"
   },
   text: {
-    code: "bg-slate-200",
+    code: "bg-slate-200 p-0.5",
+    underline: "underline",
+    strikethrough: "line-through",
+    underlineStrikethrough: "[text-decoration:underline_line-through]"
   },
   list: {
-    ul: "ml-4 list-disc",
-    listitem: "mx-2",
+    ul: "p-0 m-0 ml-4 list-disc",
+    ol: "p-0 m-0 ml-4, list-decimal",
+    listitem: "mx-8 my-2",
   },
-  quote: "text-gray-400 border-l-4 border-gray-300 pl-4",
-  table: "w-8/12",
-  tableCellHeader: "bg-slate-200 px-2 py-2 border-2 border-black",
-  tableCell: "border-2 border-black",
+  quote: "m-0 ml-5 text-sm text-gray-500 border-l-4 pl-4",
+  table: "w-11/12 max-w-full overflow-y-scroll my-7",
+  tableCellHeader: "bg-gray-200 text-start",
+  tableCell: "p-2 align-top relative border border-gray-400",
 };
 
 export default DefaultNodeStyling;


### PR DESCRIPTION
This PR updates the `DefaultNodeStyling`, an Object that associates Lexical Node Types with Tailwind styles. The Tailwind styles were derived by looking at the CSS for the Lexical Node Types in Alpha. For somethings, I also referenced Lexical's example CSS (on which the Alpha code was based). For each Node Type (paragraph, h1, table, etc.), I did a visual comparison against the KG rendering.

J=SLAP-2574
TEST=manual