### PR TITLE
Add Tailwind Styles for Lexical Dev Code Blocks.

### DIFF
--- a/src/components/richText/DefaultStyling.ts
+++ b/src/components/richText/DefaultStyling.ts
@@ -5,14 +5,16 @@ import { EditorThemeClasses } from "lexical";
  * Token Types come from the PrismJS library, which Lexical uses to power Code Blocks.
  * The Types include Comment, Variable, Operator, etc.
  */
-const attributeTokenStyles = "text-sky-700";
-const propertyTokenStyles = "text-pink-800";
-const commentTokenStyles = "text-slate-500";
-const functionTokenStyles = "text-rose-500";
-const selectorTokenStyles = "text-lime-600";
-const variableTokenStyles = "text-amber-500";
-const operatorTokenStyles = "text-yellow-700";
-const punctuationTokenStyles = "text-neutral-400";
+const stylesToTokenTypes = {
+  "text-sky-700": ['atrule', 'attr', 'keyword'],
+  "text-pink-800": ['boolean', 'constant', 'deleted', 'number', 'property', 'symbol', 'tag'],
+  "text-slate-500": ['cdata', 'comment', 'doctype', 'prolog'],
+  "text-rose-500": ['class', 'function'],
+  "text-lime-600": ['builtin', 'char', 'inserted', 'selector', 'string'],
+  "text-amber-500": ['important', 'namespace', 'regex', 'variable'],
+  "text-yellow-700": ['entity', 'operator', 'url'],
+  "text-neutral-400": ['punctuation']
+};
 
 /**
  * Default styling to apply to the different types of Lexical Rich Text
@@ -38,37 +40,11 @@ const DefaultNodeStyling: EditorThemeClasses = {
     listitem: "mx-8 my-2",
   },
   code: "bg-gray-100 block text-xs m-0 mt-2 mb-2 overflow-x-auto relative p-2",
-  codeHighlight: {
-    atrule: attributeTokenStyles,
-    attr: attributeTokenStyles,
-    boolean: propertyTokenStyles,
-    builtin: selectorTokenStyles,
-    cdata: commentTokenStyles,
-    char: selectorTokenStyles,
-    class: functionTokenStyles,
-    comment: commentTokenStyles,
-    constant: propertyTokenStyles,
-    deleted: propertyTokenStyles,
-    doctype: commentTokenStyles,
-    entity: operatorTokenStyles,
-    function: functionTokenStyles,
-    important: variableTokenStyles,
-    inserted: selectorTokenStyles,
-    keyword: attributeTokenStyles,
-    namespace: variableTokenStyles,
-    number: propertyTokenStyles,
-    operator: operatorTokenStyles,
-    prolog: commentTokenStyles,
-    property: propertyTokenStyles,
-    punctuation: punctuationTokenStyles,
-    regex: variableTokenStyles,
-    selector: selectorTokenStyles,
-    string: selectorTokenStyles,
-    symbol: propertyTokenStyles,
-    tag: propertyTokenStyles,
-    url: operatorTokenStyles,
-    variable: variableTokenStyles
-  },
+  codeHighlight: Object.fromEntries(
+    Object.entries(stylesToTokenTypes).flatMap(
+      ([style, tokenTypes]) => tokenTypes.map(type => [type, style])
+    )
+  ),
   quote: "m-0 ml-5 text-sm text-gray-500 border-l-4 pl-4",
   table: "w-11/12 max-w-full overflow-y-scroll my-7",
   tableCellHeader: "bg-gray-200 text-start",


### PR DESCRIPTION
This PR adds complete Tailwind styling for Code Blocks in Lexical Dev. A Code Block supports different kinds of tokens (variable, comment, function declaration). I added Tailwind styling for each Token type based on the Lexical Dev Example Site. The large `codeHighlight` Object is adapted from the Lexical Dev Example Theme. Each attribute is pointing to the same Token type it does in their Example Theme. 

J=SLAP-2574
TEST=manual

Compared a locally rendered Code Block with one rendered in the Lexical Example Sandbox. Verified that they were very close visually. 