### PR TITLE
Support a CommonJS build of the `Markdown` Component.

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -1,7 +1,4 @@
-This file was generated with the generate-license-file npm package!
-https://www.npmjs.com/package/generate-license-file
-
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - @babel/runtime@7.21.0
 
@@ -32,7 +29,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following npm packages may be included in this product:
+The following NPM packages may be included in this product:
 
  - @lexical/clipboard@0.8.0
  - @lexical/code@0.8.0
@@ -82,7 +79,7 @@ SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - @mapbox/geojson-rewind@0.5.2
 
@@ -104,7 +101,7 @@ PERFORMANCE OF THIS SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - @mapbox/jsonlint-lines-primitives@2.0.2
 
@@ -119,7 +116,7 @@ This fork is used by Mapbox GL JS, specifically for providing helpful error mess
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - @mapbox/mapbox-gl-supported@2.0.1
 
@@ -157,7 +154,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - @mapbox/point-geometry@0.1.0
 
@@ -179,7 +176,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - @mapbox/tiny-sdf@2.0.5
 
@@ -195,7 +192,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” 
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - @mapbox/unitbezier@0.0.1
 
@@ -232,7 +229,7 @@ http://svn.webkit.org/repository/webkit/trunk/Source/WebCore/platform/graphics/U
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - @mapbox/vector-tile@1.3.1
 
@@ -269,7 +266,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - @mapbox/whoots-js@3.1.0
 
@@ -293,12 +290,11 @@ THIS SOFTWARE.
 
 -----------
 
-The following npm packages may be included in this product:
+The following NPM packages may be included in this product:
 
- - @types/debug@4.1.7
  - @types/hast@2.3.4
  - @types/mdast@3.0.10
- - @types/parse5@6.0.3
+ - @types/parse5@5.0.3
  - @types/prop-types@15.7.5
  - @types/react@17.0.52
  - @types/scheduler@0.16.2
@@ -330,44 +326,16 @@ MIT License
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM packages may be included in this product:
 
- - @types/ms@0.7.31
-
-This package contains the following license and notice below:
-
-MIT License
-
-    Copyright (c) Microsoft Corporation. All rights reserved.
-
-    Permission is hereby granted, free of charge, to any person obtaining a copy
-    of this software and associated documentation files (the "Software"), to deal
-    in the Software without restriction, including without limitation the rights
-    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-    copies of the Software, and to permit persons to whom the Software is
-    furnished to do so, subject to the following conditions:
-
-    The above copyright notice and this permission notice shall be included in all
-    copies or substantial portions of the Software.
-
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-    SOFTWARE
-
------------
-
-The following npm packages may be included in this product:
-
- - bail@2.0.2
- - ccount@2.0.1
- - character-entities@2.0.2
- - mdast-util-to-string@3.1.1
- - unist-util-position@4.0.4
- - unist-util-visit@4.1.2
+ - bail@1.0.5
+ - ccount@1.1.0
+ - character-entities-legacy@1.1.4
+ - character-entities@1.2.4
+ - character-reference-invalid@1.1.4
+ - mdast-util-to-string@2.0.0
+ - unist-util-position@3.1.0
+ - unist-util-visit@2.0.3
 
 These packages each contain the following license and notice below:
 
@@ -396,28 +364,32 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following npm packages may be included in this product:
+The following NPM packages may be included in this product:
 
- - comma-separated-tokens@2.0.3
- - hast-util-from-parse5@7.1.2
- - hast-util-parse-selector@3.1.1
- - hast-util-raw@7.2.3
- - hast-util-sanitize@4.1.0
- - hast-util-to-parse5@7.1.0
- - hast-util-whitespace@2.0.1
- - hastscript@7.2.0
- - html-void-elements@2.0.1
- - mdast-util-to-hast@12.3.0
- - rehype-raw@6.1.1
- - rehype-sanitize@5.0.1
- - remark-rehype@10.1.0
- - space-separated-tokens@2.0.2
- - unist-util-generated@2.0.1
- - unist-util-stringify-position@3.0.3
- - unist-util-visit-parents@5.1.3
- - vfile-location@4.1.0
- - web-namespaces@2.0.1
- - zwitch@2.0.4
+ - comma-separated-tokens@1.0.8
+ - hast-to-hyperscript@9.0.1
+ - hast-util-from-parse5@6.0.1
+ - hast-util-parse-selector@2.2.5
+ - hast-util-raw@6.1.0
+ - hast-util-sanitize@3.0.2
+ - hast-util-to-parse5@6.0.0
+ - hastscript@6.0.0
+ - html-void-elements@1.0.5
+ - is-alphabetical@1.0.4
+ - is-alphanumerical@1.0.4
+ - is-decimal@1.0.4
+ - is-hexadecimal@1.0.4
+ - mdast-util-to-hast@10.2.0
+ - rehype-raw@5.1.0
+ - rehype-sanitize@4.0.0
+ - remark-rehype@8.1.0
+ - space-separated-tokens@1.1.5
+ - unist-util-generated@1.1.6
+ - unist-util-stringify-position@2.0.3
+ - unist-util-visit-parents@3.1.1
+ - vfile-location@3.2.0
+ - web-namespaces@1.1.4
+ - zwitch@1.0.5
 
 These packages each contain the following license and notice below:
 
@@ -446,7 +418,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - csscolorparser@1.0.3
 
@@ -500,7 +472,7 @@ IN THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - csstype@3.1.1
 
@@ -528,7 +500,7 @@ SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - debug@4.3.4
 
@@ -556,113 +528,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following npm packages may be included in this product:
-
- - decode-named-character-reference@1.0.2
- - mdast-util-gfm-footnote@1.0.2
- - micromark-extension-gfm-footnote@1.0.4
-
-These packages each contain the following license and notice below:
-
-(The MIT License)
-
-Copyright (c) 2021 Titus Wormer <tituswormer@gmail.com>
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-'Software'), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
------------
-
-The following npm packages may be included in this product:
-
- - dequal@2.0.3
- - kleur@4.1.5
- - mri@1.2.0
- - uvu@0.5.6
-
-These packages each contain the following license and notice below:
-
-The MIT License (MIT)
-
-Copyright (c) Luke Edwards <luke.edwards05@gmail.com> (lukeed.com)
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
------------
-
-The following npm package may be included in this product:
-
- - diff@5.1.0
-
-This package contains the following license and notice below:
-
-Software License Agreement (BSD License)
-
-Copyright (c) 2009-2015, Kevin Decker <kpdecker@gmail.com>
-
-All rights reserved.
-
-Redistribution and use of this software in source and binary forms, with or without modification,
-are permitted provided that the following conditions are met:
-
-* Redistributions of source code must retain the above
-  copyright notice, this list of conditions and the
-  following disclaimer.
-
-* Redistributions in binary form must reproduce the above
-  copyright notice, this list of conditions and the
-  following disclaimer in the documentation and/or other
-  materials provided with the distribution.
-
-* Neither the name of Kevin Decker nor the names of its
-  contributors may be used to endorse or promote products
-  derived from this software without specific prior
-  written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
-IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
-FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
-CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
-IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
-OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
------------
-
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - earcut@2.2.4
 
@@ -686,11 +552,10 @@ THIS SOFTWARE.
 
 -----------
 
-The following npm packages may be included in this product:
+The following NPM packages may be included in this product:
 
- - escape-string-regexp@5.0.0
+ - escape-string-regexp@4.0.0
  - get-stream@6.0.1
- - is-plain-obj@4.1.0
 
 These packages each contain the following license and notice below:
 
@@ -706,7 +571,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - extend@3.0.2
 
@@ -737,7 +602,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - geojson-vt@3.2.1
 
@@ -761,7 +626,7 @@ THIS SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - gl-matrix@3.4.3
 
@@ -789,7 +654,7 @@ THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - grid-index@1.1.0
 
@@ -811,7 +676,7 @@ THIS SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - ieee754@1.2.1
 
@@ -831,7 +696,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - inline-style-parser@0.1.1
 
@@ -1071,7 +936,7 @@ MIT. See [license](https://github.com/reworkcss/css/blob/v2.2.4/LICENSE) from or
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - is-buffer@2.0.5
 
@@ -1101,7 +966,25 @@ THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
+
+ - is-plain-obj@2.1.0
+
+This package contains the following license and notice below:
+
+MIT License
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+-----------
+
+The following NPM package may be included in this product:
 
  - js-tokens@4.0.0
 
@@ -1131,7 +1014,7 @@ THE SOFTWARE.
 
 -----------
 
-The following npm packages may be included in this product:
+The following NPM packages may be included in this product:
 
  - kdbush@3.0.0
  - quickselect@2.0.0
@@ -1156,11 +1039,11 @@ THIS SOFTWARE.
 
 -----------
 
-The following npm packages may be included in this product:
+The following NPM packages may be included in this product:
 
- - longest-streak@3.1.0
- - property-information@6.2.0
- - trim-lines@3.0.1
+ - longest-streak@2.0.4
+ - parse-entities@2.0.0
+ - property-information@5.6.0
 
 These packages each contain the following license and notice below:
 
@@ -1189,7 +1072,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - loose-envify@1.4.0
 
@@ -1219,7 +1102,7 @@ THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - mapbox-gl@2.11.0
 
@@ -1337,9 +1220,9 @@ THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
- - markdown-table@3.0.3
+ - markdown-table@2.0.0
 
 This package contains the following license and notice below:
 
@@ -1368,9 +1251,9 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
- - mdast-util-definitions@5.1.2
+ - mdast-util-definitions@4.0.0
 
 This package contains the following license and notice below:
 
@@ -1399,23 +1282,24 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following npm packages may be included in this product:
+The following NPM packages may be included in this product:
 
- - mdast-util-find-and-replace@2.2.2
- - mdast-util-from-markdown@1.3.0
- - mdast-util-gfm-autolink-literal@1.0.3
- - mdast-util-gfm-strikethrough@1.0.3
- - mdast-util-gfm-table@1.0.7
- - mdast-util-gfm-task-list-item@1.0.2
- - mdast-util-gfm@2.0.2
- - mdast-util-to-markdown@1.5.0
- - micromark-extension-gfm-autolink-literal@1.0.3
- - micromark-extension-gfm-strikethrough@1.0.4
- - micromark-extension-gfm-table@1.0.5
- - micromark-extension-gfm-tagfilter@1.0.1
- - micromark-extension-gfm-task-list-item@1.0.3
- - micromark-extension-gfm@2.0.1
- - remark-gfm@3.0.1
+ - mdast-util-find-and-replace@1.1.1
+ - mdast-util-from-markdown@0.8.5
+ - mdast-util-gfm-autolink-literal@0.1.3
+ - mdast-util-gfm-strikethrough@0.2.3
+ - mdast-util-gfm-table@0.1.6
+ - mdast-util-gfm-task-list-item@0.1.6
+ - mdast-util-gfm@0.1.2
+ - mdast-util-to-markdown@0.6.5
+ - micromark-extension-gfm-autolink-literal@0.5.7
+ - micromark-extension-gfm-strikethrough@0.6.5
+ - micromark-extension-gfm-table@0.4.3
+ - micromark-extension-gfm-tagfilter@0.3.0
+ - micromark-extension-gfm-task-list-item@0.3.3
+ - micromark-extension-gfm@0.3.3
+ - micromark@2.11.4
+ - remark-gfm@1.0.0
 
 These packages each contain the following license and notice below:
 
@@ -1444,4950 +1328,61 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
- - mdast-util-phrasing@3.0.1
+ - mdurl@1.0.1
 
 This package contains the following license and notice below:
 
-(The MIT License)
+Copyright (c) 2015 Vitaly Puzrin, Alex Kocharin.
 
-Copyright (c) 2017 Titus Wormer <tituswormer@gmail.com>
-Copyright (c) 2017 Victor Felder <victor@draft.li>
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-'Software'), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
 
 The above copyright notice and this permission notice shall be
 included in all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+--------------------------------------------------------------------------------
+
+.parse() is based on Joyent's node.js `url` code:
+
+Copyright Joyent, Inc. and other Node contributors. All rights reserved.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to
+deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+IN THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
-
- - micromark-core-commonmark@1.0.6
-
-This package contains the following license and notice below:
-
-# micromark-core-commonmark
-
-[![Build][build-badge]][build]
-[![Coverage][coverage-badge]][coverage]
-[![Downloads][downloads-badge]][downloads]
-[![Size][bundle-size-badge]][bundle-size]
-[![Sponsors][sponsors-badge]][opencollective]
-[![Backers][backers-badge]][opencollective]
-[![Chat][chat-badge]][chat]
-
-The core CommonMark constructs needed to tokenize markdown.
-Some of these can be [turned off][disable], but they are often essential to
-markdown and weird things might happen.
-
-## Contents
-
-*   [Install](#install)
-*   [Use](#use)
-*   [API](#api)
-*   [Security](#security)
-*   [Contribute](#contribute)
-*   [License](#license)
-
-## Install
-
-[npm][]:
-
-```sh
-npm install micromark-core-commonmark
-```
-
-## Use
-
-```js
-import {autolink} from 'micromark-core-commonmark'
-
-console.log(autolink) // Do things with `autolink`.
-```
-
-## API
-
-This module exports the following identifiers: `attention`, `autolink`,
-`blankLine`, `blockQuote`, `characterEscape`, `characterReference`,
-`codeFenced`, `codeIndented`, `codeText`, `content`, `definition`,
-`hardBreakEscape`, `headingAtx`, `htmlFlow`, `htmlText`, `labelEnd`,
-`labelStartImage`, `labelStartLink`, `lineEnding`, `list`, `setextUnderline`,
-`thematicBreak`.
-There is no default export.
-
-Each identifier refers to a [construct](https://github.com/micromark/micromark#constructs).
-
-See the code for more on the exported constructs.
-
-## Security
-
-See [`security.md`][securitymd] in [`micromark/.github`][health] for how to
-submit a security report.
-
-## Contribute
-
-See [`contributing.md`][contributing] in [`micromark/.github`][health] for ways
-to get started.
-See [`support.md`][support] for ways to get help.
-
-This project has a [code of conduct][coc].
-By interacting with this repository, organisation, or community you agree to
-abide by its terms.
-
-## License
-
-[MIT][license] © [Titus Wormer][author]
-
-<!-- Definitions -->
-
-[build-badge]: https://github.com/micromark/micromark/workflows/main/badge.svg
-
-[build]: https://github.com/micromark/micromark/actions
-
-[coverage-badge]: https://img.shields.io/codecov/c/github/micromark/micromark.svg
-
-[coverage]: https://codecov.io/github/micromark/micromark
-
-[downloads-badge]: https://img.shields.io/npm/dm/micromark-core-commonmark.svg
-
-[downloads]: https://www.npmjs.com/package/micromark-core-commonmark
-
-[bundle-size-badge]: https://img.shields.io/bundlephobia/minzip/micromark-core-commonmark.svg
-
-[bundle-size]: https://bundlephobia.com/result?p=micromark-core-commonmark
-
-[sponsors-badge]: https://opencollective.com/unified/sponsors/badge.svg
-
-[backers-badge]: https://opencollective.com/unified/backers/badge.svg
-
-[opencollective]: https://opencollective.com/unified
-
-[npm]: https://docs.npmjs.com/cli/install
-
-[chat-badge]: https://img.shields.io/badge/chat-discussions-success.svg
-
-[chat]: https://github.com/micromark/micromark/discussions
-
-[license]: https://github.com/micromark/micromark/blob/main/license
-
-[author]: https://wooorm.com
-
-[health]: https://github.com/micromark/.github
-
-[securitymd]: https://github.com/micromark/.github/blob/HEAD/security.md
-
-[contributing]: https://github.com/micromark/.github/blob/HEAD/contributing.md
-
-[support]: https://github.com/micromark/.github/blob/HEAD/support.md
-
-[coc]: https://github.com/micromark/.github/blob/HEAD/code-of-conduct.md
-
-[disable]: https://github.com/micromark/micromark#case-turn-off-constructs
-
------------
-
-The following npm package may be included in this product:
-
- - micromark-factory-destination@1.0.0
-
-This package contains the following license and notice below:
-
-# micromark-factory-destination
-
-[![Build][build-badge]][build]
-[![Coverage][coverage-badge]][coverage]
-[![Downloads][downloads-badge]][downloads]
-[![Size][bundle-size-badge]][bundle-size]
-[![Sponsors][sponsors-badge]][opencollective]
-[![Backers][backers-badge]][opencollective]
-[![Chat][chat-badge]][chat]
-
-micromark factory to parse destinations (found in resources, definitions).
-
-## Contents
-
-*   [Install](#install)
-*   [Use](#use)
-*   [API](#api)
-    *   [`factoryDestination(…)`](#factorydestination)
-*   [Security](#security)
-*   [Contribute](#contribute)
-*   [License](#license)
-
-## Install
-
-[npm][]:
-
-```sh
-npm install micromark-factory-destination
-```
-
-## Use
-
-```js
-import {factoryDestination} from 'micromark-factory-destination'
-import {codes} from 'micromark-util-symbol/codes'
-import {types} from 'micromark-util-symbol/types'
-
-// A micromark tokenizer that uses the factory:
-/** @type {Tokenizer} */
-function tokenizeResource(effects, ok, nok) {
-  return start
-
-  // …
-
-  /** @type {State} */
-  function open(code) {
-    if (code === codes.rightParenthesis) {
-      return end(code)
-    }
-
-    return factoryDestination(
-      effects,
-      destinationAfter,
-      nok,
-      types.resourceDestination,
-      types.resourceDestinationLiteral,
-      types.resourceDestinationLiteralMarker,
-      types.resourceDestinationRaw,
-      types.resourceDestinationString,
-      constants.linkResourceDestinationBalanceMax
-    )(code)
-  }
-
-  // …
-}
-```
-
-## API
-
-This module exports the following identifiers: `factoryDestination`.
-There is no default export.
-
-### `factoryDestination(…)`
-
-###### Parameters
-
-*   `effects` (`Effects`) — Context
-*   `ok` (`State`) — State switched to when successful
-*   `nok` (`State`) — State switched to when not successful
-*   `type` (`string`) — Token type for whole (`<a>` or `b`)
-*   `literalType` (`string`) — Token type when enclosed (`<a>`)
-*   `literalMarkerType` (`string`) — Token type for enclosing (`<` and `>`)
-*   `rawType` (`string`) — Token type when not enclosed (`b`)
-*   `stringType` (`string`) — Token type for the URI (`a` or `b`)
-*   `max` (`number`, default: `Infinity`) — Max depth of nested parens
-
-###### Returns
-
-`State`.
-
-###### Examples
-
-```markdown
-<a>
-<a\>b>
-<a b>
-<a)>
-a
-a\)b
-a(b)c
-a(b)
-```
-
-## Security
-
-See [`security.md`][securitymd] in [`micromark/.github`][health] for how to
-submit a security report.
-
-## Contribute
-
-See [`contributing.md`][contributing] in [`micromark/.github`][health] for ways
-to get started.
-See [`support.md`][support] for ways to get help.
-
-This project has a [code of conduct][coc].
-By interacting with this repository, organisation, or community you agree to
-abide by its terms.
-
-## License
-
-[MIT][license] © [Titus Wormer][author]
-
-<!-- Definitions -->
-
-[build-badge]: https://github.com/micromark/micromark/workflows/main/badge.svg
-
-[build]: https://github.com/micromark/micromark/actions
-
-[coverage-badge]: https://img.shields.io/codecov/c/github/micromark/micromark.svg
-
-[coverage]: https://codecov.io/github/micromark/micromark
-
-[downloads-badge]: https://img.shields.io/npm/dm/micromark-factory-destination.svg
-
-[downloads]: https://www.npmjs.com/package/micromark-factory-destination
-
-[bundle-size-badge]: https://img.shields.io/bundlephobia/minzip/micromark-factory-destination.svg
-
-[bundle-size]: https://bundlephobia.com/result?p=micromark-factory-destination
-
-[sponsors-badge]: https://opencollective.com/unified/sponsors/badge.svg
-
-[backers-badge]: https://opencollective.com/unified/backers/badge.svg
-
-[opencollective]: https://opencollective.com/unified
-
-[npm]: https://docs.npmjs.com/cli/install
-
-[chat-badge]: https://img.shields.io/badge/chat-discussions-success.svg
-
-[chat]: https://github.com/micromark/micromark/discussions
-
-[license]: https://github.com/micromark/micromark/blob/main/license
-
-[author]: https://wooorm.com
-
-[health]: https://github.com/micromark/.github
-
-[securitymd]: https://github.com/micromark/.github/blob/HEAD/security.md
-
-[contributing]: https://github.com/micromark/.github/blob/HEAD/contributing.md
-
-[support]: https://github.com/micromark/.github/blob/HEAD/support.md
-
-[coc]: https://github.com/micromark/.github/blob/HEAD/code-of-conduct.md
-
------------
-
-The following npm package may be included in this product:
-
- - micromark-factory-label@1.0.2
-
-This package contains the following license and notice below:
-
-# micromark-factory-label
-
-[![Build][build-badge]][build]
-[![Coverage][coverage-badge]][coverage]
-[![Downloads][downloads-badge]][downloads]
-[![Size][bundle-size-badge]][bundle-size]
-[![Sponsors][sponsors-badge]][opencollective]
-[![Backers][backers-badge]][opencollective]
-[![Chat][chat-badge]][chat]
-
-micromark factory to parse labels (found in media, definitions).
-
-## Contents
-
-*   [Install](#install)
-*   [Use](#use)
-*   [API](#api)
-    *   [`factoryLabel(…)`](#factorylabel)
-*   [Security](#security)
-*   [Contribute](#contribute)
-*   [License](#license)
-
-## Install
-
-[npm][]:
-
-```sh
-npm install micromark-factory-label
-```
-
-## Use
-
-```js
-import {ok as assert} from 'uvu/assert'
-import {factoryLabel} from 'micromark-factory-label'
-import {codes} from 'micromark-util-symbol/codes'
-import {types} from 'micromark-util-symbol/types'
-
-// A micromark tokenizer that uses the factory:
-/** @type {Tokenizer} */
-function tokenizeDefinition(effects, ok, nok) {
-  return start
-
-  // …
-
-  /** @type {State} */
-  function start(code) {
-    assert(code === codes.leftSquareBracket, 'expected `[`')
-    effects.enter(types.definition)
-    return factoryLabel.call(
-      self,
-      effects,
-      labelAfter,
-      nok,
-      types.definitionLabel,
-      types.definitionLabelMarker,
-      types.definitionLabelString
-    )(code)
-  }
-
-  // …
-}
-```
-
-## API
-
-This module exports the following identifiers: `factoryLabel`.
-There is no default export.
-
-### `factoryLabel(…)`
-
-Note that labels in markdown are capped at 999 characters in the string.
-
-###### Parameters
-
-*   `this` (`TokenizeContext`) — Tokenize context
-*   `effects` (`Effects`) — Context
-*   `ok` (`State`) — State switched to when successful
-*   `nok` (`State`) — State switched to when not successful
-*   `type` (`string`) — Token type for whole (`[a]`)
-*   `markerType` (`string`) — Token type for the markers (`[` and `]`)
-*   `stringType` (`string`) — Token type for the identifier (`a`)
-
-###### Returns
-
-`State`.
-
-###### Examples
-
-```markdown
-[a]
-[a
-b]
-[a\]b]
-```
-
-## Security
-
-See [`security.md`][securitymd] in [`micromark/.github`][health] for how to
-submit a security report.
-
-## Contribute
-
-See [`contributing.md`][contributing] in [`micromark/.github`][health] for ways
-to get started.
-See [`support.md`][support] for ways to get help.
-
-This project has a [code of conduct][coc].
-By interacting with this repository, organisation, or community you agree to
-abide by its terms.
-
-## License
-
-[MIT][license] © [Titus Wormer][author]
-
-<!-- Definitions -->
-
-[build-badge]: https://github.com/micromark/micromark/workflows/main/badge.svg
-
-[build]: https://github.com/micromark/micromark/actions
-
-[coverage-badge]: https://img.shields.io/codecov/c/github/micromark/micromark.svg
-
-[coverage]: https://codecov.io/github/micromark/micromark
-
-[downloads-badge]: https://img.shields.io/npm/dm/micromark-factory-label.svg
-
-[downloads]: https://www.npmjs.com/package/micromark-factory-label
-
-[bundle-size-badge]: https://img.shields.io/bundlephobia/minzip/micromark-factory-label.svg
-
-[bundle-size]: https://bundlephobia.com/result?p=micromark-factory-label
-
-[sponsors-badge]: https://opencollective.com/unified/sponsors/badge.svg
-
-[backers-badge]: https://opencollective.com/unified/backers/badge.svg
-
-[opencollective]: https://opencollective.com/unified
-
-[npm]: https://docs.npmjs.com/cli/install
-
-[chat-badge]: https://img.shields.io/badge/chat-discussions-success.svg
-
-[chat]: https://github.com/micromark/micromark/discussions
-
-[license]: https://github.com/micromark/micromark/blob/main/license
-
-[author]: https://wooorm.com
-
-[health]: https://github.com/micromark/.github
-
-[securitymd]: https://github.com/micromark/.github/blob/HEAD/security.md
-
-[contributing]: https://github.com/micromark/.github/blob/HEAD/contributing.md
-
-[support]: https://github.com/micromark/.github/blob/HEAD/support.md
-
-[coc]: https://github.com/micromark/.github/blob/HEAD/code-of-conduct.md
-
------------
-
-The following npm package may be included in this product:
-
- - micromark-factory-space@1.0.0
-
-This package contains the following license and notice below:
-
-# micromark-factory-space
-
-[![Build][build-badge]][build]
-[![Coverage][coverage-badge]][coverage]
-[![Downloads][downloads-badge]][downloads]
-[![Size][bundle-size-badge]][bundle-size]
-[![Sponsors][sponsors-badge]][opencollective]
-[![Backers][backers-badge]][opencollective]
-[![Chat][chat-badge]][chat]
-
-micromark factory to parse [markdown space][markdown-space] (found in lots of
-places).
-
-## Contents
-
-*   [Install](#install)
-*   [Use](#use)
-*   [API](#api)
-    *   [`factorySpace(…)`](#factoryspace)
-*   [Security](#security)
-*   [Contribute](#contribute)
-*   [License](#license)
-
-## Install
-
-[npm][]:
-
-```sh
-npm install micromark-factory-space
-```
-
-## Use
-
-```js
-import {factorySpace} from 'micromark-factory-space'
-import {codes} from 'micromark-util-symbol/codes'
-import {types} from 'micromark-util-symbol/types'
-
-// A micromark tokenizer that uses the factory:
-/** @type {Tokenizer} */
-function tokenizeCodeFenced(effects, ok, nok) {
-  return start
-
-  // …
-
-  /** @type {State} */
-  function info(code) {
-    if (code === codes.eof || markdownLineEndingOrSpace(code)) {
-      effects.exit(types.chunkString)
-      effects.exit(types.codeFencedFenceInfo)
-      return factorySpace(effects, infoAfter, types.whitespace)(code)
-    }
-
-    if (code === codes.graveAccent && code === marker) return nok(code)
-    effects.consume(code)
-    return info
-  }
-
-  // …
-}
-```
-
-## API
-
-This module exports the following identifiers: `factorySpace`.
-There is no default export.
-
-### `factorySpace(…)`
-
-Note that there is no `nok` parameter:
-
-*   spaces in markdown are often optional, in which case this factory can be
-    used and `ok` will be switched to whether spaces were found or not,
-*   One space character can be detected with
-    [markdownSpace(code)][markdown-space] right before using `factorySpace`
-
-###### Parameters
-
-*   `effects` (`Effects`) — Context
-*   `ok` (`State`) — State switched to when successful
-*   `type` (`string`) — Token type for whole (`' \t'`)
-*   `max` (`number`, default: `Infinity`) — Max size of whitespace
-
-###### Returns
-
-`State`.
-
-###### Examples
-
-Where `␉` represents a tab (plus how much it expands) and `␠` represents a
-single space.
-
-```markdown
-␉
-␠␠␠␠
-␉␠
-```
-
-## Security
-
-See [`security.md`][securitymd] in [`micromark/.github`][health] for how to
-submit a security report.
-
-## Contribute
-
-See [`contributing.md`][contributing] in [`micromark/.github`][health] for ways
-to get started.
-See [`support.md`][support] for ways to get help.
-
-This project has a [code of conduct][coc].
-By interacting with this repository, organisation, or community you agree to
-abide by its terms.
-
-## License
-
-[MIT][license] © [Titus Wormer][author]
-
-<!-- Definitions -->
-
-[build-badge]: https://github.com/micromark/micromark/workflows/main/badge.svg
-
-[build]: https://github.com/micromark/micromark/actions
-
-[coverage-badge]: https://img.shields.io/codecov/c/github/micromark/micromark.svg
-
-[coverage]: https://codecov.io/github/micromark/micromark
-
-[downloads-badge]: https://img.shields.io/npm/dm/micromark-factory-space.svg
-
-[downloads]: https://www.npmjs.com/package/micromark-factory-space
-
-[bundle-size-badge]: https://img.shields.io/bundlephobia/minzip/micromark-factory-space.svg
-
-[bundle-size]: https://bundlephobia.com/result?p=micromark-factory-space
-
-[sponsors-badge]: https://opencollective.com/unified/sponsors/badge.svg
-
-[backers-badge]: https://opencollective.com/unified/backers/badge.svg
-
-[opencollective]: https://opencollective.com/unified
-
-[npm]: https://docs.npmjs.com/cli/install
-
-[chat-badge]: https://img.shields.io/badge/chat-discussions-success.svg
-
-[chat]: https://github.com/micromark/micromark/discussions
-
-[license]: https://github.com/micromark/micromark/blob/main/license
-
-[author]: https://wooorm.com
-
-[health]: https://github.com/micromark/.github
-
-[securitymd]: https://github.com/micromark/.github/blob/HEAD/security.md
-
-[contributing]: https://github.com/micromark/.github/blob/HEAD/contributing.md
-
-[support]: https://github.com/micromark/.github/blob/HEAD/support.md
-
-[coc]: https://github.com/micromark/.github/blob/HEAD/code-of-conduct.md
-
-[markdown-space]: https://github.com/micromark/micromark/tree/main/packages/micromark-util-character#markdownspacecode
-
------------
-
-The following npm package may be included in this product:
-
- - micromark-factory-title@1.0.2
-
-This package contains the following license and notice below:
-
-# micromark-factory-title
-
-[![Build][build-badge]][build]
-[![Coverage][coverage-badge]][coverage]
-[![Downloads][downloads-badge]][downloads]
-[![Size][bundle-size-badge]][bundle-size]
-[![Sponsors][sponsors-badge]][opencollective]
-[![Backers][backers-badge]][opencollective]
-[![Chat][chat-badge]][chat]
-
-micromark factory to parse markdown titles (found in resources, definitions).
-
-## Contents
-
-*   [Install](#install)
-*   [Use](#use)
-*   [API](#api)
-    *   [`factoryTitle(…)`](#factorytitle)
-*   [Security](#security)
-*   [Contribute](#contribute)
-*   [License](#license)
-
-## Install
-
-[npm][]:
-
-```sh
-npm install micromark-factory-title
-```
-
-## Use
-
-```js
-import {factoryTitle} from 'micromark-factory-title'
-import {codes} from 'micromark-util-symbol/codes'
-import {types} from 'micromark-util-symbol/types'
-
-// A micromark tokenizer that uses the factory:
-/** @type {Tokenizer} */
-function tokenizeDefinition(effects, ok, nok) {
-  return start
-
-  // …
-
-  /** @type {State} */
-  function before(code) {
-    if (
-      code === codes.quotationMark ||
-      code === codes.apostrophe ||
-      code === codes.leftParenthesis
-    ) {
-      return factoryTitle(
-        effects,
-        factorySpace(effects, after, types.whitespace),
-        nok,
-        types.definitionTitle,
-        types.definitionTitleMarker,
-        types.definitionTitleString
-      )(code)
-    }
-
-    return nok(code)
-  }
-
-  // …
-}
-```
-
-## API
-
-This module exports the following identifiers: `factoryTitle`.
-There is no default export.
-
-### `factoryTitle(…)`
-
-###### Parameters
-
-*   `effects` (`Effects`) — Context
-*   `ok` (`State`) — State switched to when successful
-*   `nok` (`State`) — State switched to when not successful
-*   `type` (`string`) — Token type for whole (`"a"`, `'b'`, `(c)`)
-*   `markerType` (`string`) — Token type for the markers (`"`, `'`, `(`, and
-    `)`)
-*   `stringType` (`string`) — Token type for the value (`a`)
-
-###### Returns
-
-`State`.
-
-###### Examples
-
-```markdown
-"a"
-'b'
-(c)
-"a
-b"
-'a
-    b'
-(a\)b)
-```
-
-## Security
-
-See [`security.md`][securitymd] in [`micromark/.github`][health] for how to
-submit a security report.
-
-## Contribute
-
-See [`contributing.md`][contributing] in [`micromark/.github`][health] for ways
-to get started.
-See [`support.md`][support] for ways to get help.
-
-This project has a [code of conduct][coc].
-By interacting with this repository, organisation, or community you agree to
-abide by its terms.
-
-## License
-
-[MIT][license] © [Titus Wormer][author]
-
-<!-- Definitions -->
-
-[build-badge]: https://github.com/micromark/micromark/workflows/main/badge.svg
-
-[build]: https://github.com/micromark/micromark/actions
-
-[coverage-badge]: https://img.shields.io/codecov/c/github/micromark/micromark.svg
-
-[coverage]: https://codecov.io/github/micromark/micromark
-
-[downloads-badge]: https://img.shields.io/npm/dm/micromark-factory-title.svg
-
-[downloads]: https://www.npmjs.com/package/micromark-factory-title
-
-[bundle-size-badge]: https://img.shields.io/bundlephobia/minzip/micromark-factory-title.svg
-
-[bundle-size]: https://bundlephobia.com/result?p=micromark-factory-title
-
-[sponsors-badge]: https://opencollective.com/unified/sponsors/badge.svg
-
-[backers-badge]: https://opencollective.com/unified/backers/badge.svg
-
-[opencollective]: https://opencollective.com/unified
-
-[npm]: https://docs.npmjs.com/cli/install
-
-[chat-badge]: https://img.shields.io/badge/chat-discussions-success.svg
-
-[chat]: https://github.com/micromark/micromark/discussions
-
-[license]: https://github.com/micromark/micromark/blob/main/license
-
-[author]: https://wooorm.com
-
-[health]: https://github.com/micromark/.github
-
-[securitymd]: https://github.com/micromark/.github/blob/HEAD/security.md
-
-[contributing]: https://github.com/micromark/.github/blob/HEAD/contributing.md
-
-[support]: https://github.com/micromark/.github/blob/HEAD/support.md
-
-[coc]: https://github.com/micromark/.github/blob/HEAD/code-of-conduct.md
-
------------
-
-The following npm package may be included in this product:
-
- - micromark-factory-whitespace@1.0.0
-
-This package contains the following license and notice below:
-
-# micromark-factory-whitespace
-
-[![Build][build-badge]][build]
-[![Coverage][coverage-badge]][coverage]
-[![Downloads][downloads-badge]][downloads]
-[![Size][bundle-size-badge]][bundle-size]
-[![Sponsors][sponsors-badge]][opencollective]
-[![Backers][backers-badge]][opencollective]
-[![Chat][chat-badge]][chat]
-
-micromark factory to parse [markdown line endings or spaces][ws] (found in lots
-of places).
-
-## Contents
-
-*   [Install](#install)
-*   [Use](#use)
-*   [API](#api)
-    *   [`factoryWhitespace(…)`](#factorywhitespace)
-*   [Security](#security)
-*   [Contribute](#contribute)
-*   [License](#license)
-
-## Install
-
-[npm][]:
-
-```sh
-npm install micromark-factory-whitespace
-```
-
-## Use
-
-```js
-import {factoryWhitespace} from 'micromark-factory-whitespace'
-import {codes} from 'micromark-util-symbol/codes'
-import {types} from 'micromark-util-symbol/types'
-
-// A micromark tokenizer that uses the factory:
-/** @type {Tokenizer} */
-function tokenizeTitle(effects, ok, nok) {
-  return start
-
-  /** @type {State} */
-  function start(code) {
-    return markdownLineEndingOrSpace(code)
-      ? factoryWhitespace(effects, before)(code)
-      : nok(code)
-  }
-
-  // …
-}
-```
-
-## API
-
-This module exports the following identifiers: `factoryWhitespace`.
-There is no default export.
-
-### `factoryWhitespace(…)`
-
-Note that there is no `nok` parameter:
-
-*   line endings or spaces in markdown are often optional, in which case this
-    factory can be used and `ok` will be switched to whether spaces were found
-    or not,
-*   One line ending or space can be detected with
-    [markdownLineEndingOrSpace(code)][ws] right before using `factoryWhitespace`
-
-###### Parameters
-
-*   `effects` (`Effects`) — Context
-*   `ok` (`State`) — State switched to when successful
-
-###### Returns
-
-`State`.
-
-## Security
-
-See [`security.md`][securitymd] in [`micromark/.github`][health] for how to
-submit a security report.
-
-## Contribute
-
-See [`contributing.md`][contributing] in [`micromark/.github`][health] for ways
-to get started.
-See [`support.md`][support] for ways to get help.
-
-This project has a [code of conduct][coc].
-By interacting with this repository, organisation, or community you agree to
-abide by its terms.
-
-## License
-
-[MIT][license] © [Titus Wormer][author]
-
-<!-- Definitions -->
-
-[build-badge]: https://github.com/micromark/micromark/workflows/main/badge.svg
-
-[build]: https://github.com/micromark/micromark/actions
-
-[coverage-badge]: https://img.shields.io/codecov/c/github/micromark/micromark.svg
-
-[coverage]: https://codecov.io/github/micromark/micromark
-
-[downloads-badge]: https://img.shields.io/npm/dm/micromark-factory-whitespace.svg
-
-[downloads]: https://www.npmjs.com/package/micromark-factory-whitespace
-
-[bundle-size-badge]: https://img.shields.io/bundlephobia/minzip/micromark-factory-whitespace.svg
-
-[bundle-size]: https://bundlephobia.com/result?p=micromark-factory-whitespace
-
-[sponsors-badge]: https://opencollective.com/unified/sponsors/badge.svg
-
-[backers-badge]: https://opencollective.com/unified/backers/badge.svg
-
-[opencollective]: https://opencollective.com/unified
-
-[npm]: https://docs.npmjs.com/cli/install
-
-[chat-badge]: https://img.shields.io/badge/chat-discussions-success.svg
-
-[chat]: https://github.com/micromark/micromark/discussions
-
-[license]: https://github.com/micromark/micromark/blob/main/license
-
-[author]: https://wooorm.com
-
-[health]: https://github.com/micromark/.github
-
-[securitymd]: https://github.com/micromark/.github/blob/HEAD/security.md
-
-[contributing]: https://github.com/micromark/.github/blob/HEAD/contributing.md
-
-[support]: https://github.com/micromark/.github/blob/HEAD/support.md
-
-[coc]: https://github.com/micromark/.github/blob/HEAD/code-of-conduct.md
-
-[ws]: https://github.com/micromark/micromark/tree/main/packages/micromark-util-character#markdownlineendingorspacecode
-
------------
-
-The following npm package may be included in this product:
-
- - micromark-util-character@1.1.0
-
-This package contains the following license and notice below:
-
-# micromark-util-character
-
-[![Build][build-badge]][build]
-[![Coverage][coverage-badge]][coverage]
-[![Downloads][downloads-badge]][downloads]
-[![Size][bundle-size-badge]][bundle-size]
-[![Sponsors][sponsors-badge]][opencollective]
-[![Backers][backers-badge]][opencollective]
-[![Chat][chat-badge]][chat]
-
-micromark utility to handle [character codes](https://github.com/micromark/micromark#preprocess).
-
-## Contents
-
-*   [Install](#install)
-*   [Use](#use)
-*   [API](#api)
-    *   [`asciiAlpha(code)`](#asciialphacode)
-    *   [`asciiDigit(code)`](#asciidigitcode)
-    *   [`asciiHexDigit(code)`](#asciihexdigitcode)
-    *   [`asciiAlphanumeric(code)`](#asciialphanumericcode)
-    *   [`asciiPunctuation(code)`](#asciipunctuationcode)
-    *   [`asciiAtext(code)`](#asciiatextcode)
-    *   [`asciiControl(code)`](#asciicontrolcode)
-    *   [`markdownLineEndingOrSpace(code)`](#markdownlineendingorspacecode)
-    *   [`markdownLineEnding(code)`](#markdownlineendingcode)
-    *   [`markdownSpace(code)`](#markdownspacecode)
-    *   [`unicodeWhitespace(code)`](#unicodewhitespacecode)
-    *   [`unicodePunctuation(code)`](#unicodepunctuationcode)
-*   [Security](#security)
-*   [Contribute](#contribute)
-*   [License](#license)
-
-## Install
-
-[npm][]:
-
-```sh
-npm install micromark-util-character
-```
-
-## Use
-
-```js
-import {asciiAlpha} from 'micromark-util-character'
-
-console.log(asciiAlpha(64)) // false
-console.log(asciiAlpha(65)) // true
-```
-
-## API
-
-This module exports the following identifiers: `asciiAlpha`,
-`asciiAlphanumeric`, `asciiAtext`, `asciiControl`, `asciiDigit`,
-`asciiHexDigit`, `asciiPunctuation`, `markdownLineEnding`,
-`markdownLineEndingOrSpace`, `markdownSpace`, `unicodePunctuation`,
-`unicodeWhitespace`.
-There is no default export.
-
-### `asciiAlpha(code)`
-
-Check whether the
-[character code](https://github.com/micromark/micromark#preprocess)
-represents an ASCII alpha (`a` through `z`,
-case insensitive).
-
-An **ASCII alpha** is an ASCII upper alpha or ASCII lower alpha.
-
-An **ASCII upper alpha** is a character in the inclusive range U+0041 (`A`)
-to U+005A (`Z`).
-
-An **ASCII lower alpha** is a character in the inclusive range U+0061 (`a`)
-to U+007A (`z`).
-
-### `asciiDigit(code)`
-
-Check whether the
-[character code](https://github.com/micromark/micromark#preprocess)
-represents an ASCII digit (`0` through `9`).
-
-An **ASCII digit** is a character in the inclusive range U+0030 (`0`) to
-U+0039 (`9`).
-
-### `asciiHexDigit(code)`
-
-Check whether the
-[character code](https://github.com/micromark/micromark#preprocess)
-represents an ASCII hex digit (`a` through `f`, case insensitive, or `0` through
-`9`).
-
-An **ASCII hex digit** is an ASCII digit (see `asciiDigit`), ASCII upper hex
-digit, or an ASCII lower hex digit.
-
-An **ASCII upper hex digit** is a character in the inclusive range U+0041
-(`A`) to U+0046 (`F`).
-
-An **ASCII lower hex digit** is a character in the inclusive range U+0061
-(`a`) to U+0066 (`f`).
-
-### `asciiAlphanumeric(code)`
-
-Check whether the
-[character code](https://github.com/micromark/micromark#preprocess)
-represents an ASCII alphanumeric (`a` through `z`, case insensitive, or `0`
-through `9`).
-
-An **ASCII alphanumeric** is an ASCII digit (see `asciiDigit`) or ASCII alpha
-(see `asciiAlpha`).
-
-### `asciiPunctuation(code)`
-
-Check whether the
-[character code](https://github.com/micromark/micromark#preprocess)
-represents ASCII punctuation.
-
-An **ASCII punctuation** is a character in the inclusive ranges U+0021
-EXCLAMATION MARK (`!`) to U+002F SLASH (`/`), U+003A COLON (`:`) to U+0040 AT
-SIGN (`@`), U+005B LEFT SQUARE BRACKET (`[`) to U+0060 GRAVE ACCENT
-(`` ` ``), or U+007B LEFT CURLY BRACE (`{`) to U+007E TILDE (`~`).
-
-### `asciiAtext(code)`
-
-Check whether the
-[character code](https://github.com/micromark/micromark#preprocess)
-represents an ASCII atext.
-
-atext is an ASCII alphanumeric (see `asciiAlphanumeric`), or a character in
-the inclusive ranges U+0023 NUMBER SIGN (`#`) to U+0027 APOSTROPHE (`'`),
-U+002A ASTERISK (`*`), U+002B PLUS SIGN (`+`), U+002D DASH (`-`), U+002F
-SLASH (`/`), U+003D EQUALS TO (`=`), U+003F QUESTION MARK (`?`), U+005E
-CARET (`^`) to U+0060 GRAVE ACCENT (`` ` ``), or U+007B LEFT CURLY BRACE
-(`{`) to U+007E TILDE (`~`) (**\[RFC5322]**).
-
-See **\[RFC5322]**:\
-[Internet Message Format](https://tools.ietf.org/html/rfc5322).\
-P. Resnick.\
-IETF.
-
-### `asciiControl(code)`
-
-Check whether a
-[character code](https://github.com/micromark/micromark#preprocess)
-is an ASCII control character.
-
-An **ASCII control** is a character in the inclusive range U+0000 NULL (NUL)
-to U+001F (US), or U+007F (DEL).
-
-### `markdownLineEndingOrSpace(code)`
-
-Check whether a
-[character code](https://github.com/micromark/micromark#preprocess)
-is a markdown line ending (see `markdownLineEnding`) or markdown space (see
-`markdownSpace`).
-
-### `markdownLineEnding(code)`
-
-Check whether a
-[character code](https://github.com/micromark/micromark#preprocess)
-is a markdown line ending.
-
-A **markdown line ending** is the virtual characters M-0003 CARRIAGE RETURN
-LINE FEED (CRLF), M-0004 LINE FEED (LF) and M-0005 CARRIAGE RETURN (CR).
-
-In micromark, the actual character U+000A LINE FEED (LF) and U+000D CARRIAGE
-RETURN (CR) are replaced by these virtual characters depending on whether
-they occurred together.
-
-### `markdownSpace(code)`
-
-Check whether a
-[character code](https://github.com/micromark/micromark#preprocess)
-is a markdown space.
-
-A **markdown space** is the concrete character U+0020 SPACE (SP) and the
-virtual characters M-0001 VIRTUAL SPACE (VS) and M-0002 HORIZONTAL TAB (HT).
-
-In micromark, the actual character U+0009 CHARACTER TABULATION (HT) is
-replaced by one M-0002 HORIZONTAL TAB (HT) and between 0 and 3 M-0001 VIRTUAL
-SPACE (VS) characters, depending on the column at which the tab occurred.
-
-### `unicodeWhitespace(code)`
-
-Check whether the
-[character code](https://github.com/micromark/micromark#preprocess)
-represents Unicode whitespace.
-
-Note that this does handle micromark specific markdown whitespace characters.
-See `markdownLineEndingOrSpace` to check that.
-
-A **Unicode whitespace** is a character in the Unicode `Zs` (Separator,
-Space) category, or U+0009 CHARACTER TABULATION (HT), U+000A LINE FEED (LF),
-U+000C (FF), or U+000D CARRIAGE RETURN (CR) (**\[UNICODE]**).
-
-See **\[UNICODE]**:\
-[The Unicode Standard](https://www.unicode.org/versions/).\
-Unicode Consortium.
-
-### `unicodePunctuation(code)`
-
-Check whether the
-[character code](https://github.com/micromark/micromark#preprocess)
-represents Unicode punctuation.
-
-A **Unicode punctuation** is a character in the Unicode `Pc` (Punctuation,
-Connector), `Pd` (Punctuation, Dash), `Pe` (Punctuation, Close), `Pf`
-(Punctuation, Final quote), `Pi` (Punctuation, Initial quote), `Po`
-(Punctuation, Other), or `Ps` (Punctuation, Open) categories, or an ASCII
-punctuation (see `asciiPunctuation`) (**\[UNICODE]**).
-
-See **\[UNICODE]**:\
-[The Unicode Standard](https://www.unicode.org/versions/).\
-Unicode Consortium.
-
-## Security
-
-See [`security.md`][securitymd] in [`micromark/.github`][health] for how to
-submit a security report.
-
-## Contribute
-
-See [`contributing.md`][contributing] in [`micromark/.github`][health] for ways
-to get started.
-See [`support.md`][support] for ways to get help.
-
-This project has a [code of conduct][coc].
-By interacting with this repository, organisation, or community you agree to
-abide by its terms.
-
-## License
-
-[MIT][license] © [Titus Wormer][author]
-
-<!-- Definitions -->
-
-[build-badge]: https://github.com/micromark/micromark/workflows/main/badge.svg
-
-[build]: https://github.com/micromark/micromark/actions
-
-[coverage-badge]: https://img.shields.io/codecov/c/github/micromark/micromark.svg
-
-[coverage]: https://codecov.io/github/micromark/micromark
-
-[downloads-badge]: https://img.shields.io/npm/dm/micromark-util-character.svg
-
-[downloads]: https://www.npmjs.com/package/micromark-util-character
-
-[bundle-size-badge]: https://img.shields.io/bundlephobia/minzip/micromark-util-character.svg
-
-[bundle-size]: https://bundlephobia.com/result?p=micromark-util-character
-
-[sponsors-badge]: https://opencollective.com/unified/sponsors/badge.svg
-
-[backers-badge]: https://opencollective.com/unified/backers/badge.svg
-
-[opencollective]: https://opencollective.com/unified
-
-[npm]: https://docs.npmjs.com/cli/install
-
-[chat-badge]: https://img.shields.io/badge/chat-discussions-success.svg
-
-[chat]: https://github.com/micromark/micromark/discussions
-
-[license]: https://github.com/micromark/micromark/blob/main/license
-
-[author]: https://wooorm.com
-
-[health]: https://github.com/micromark/.github
-
-[securitymd]: https://github.com/micromark/.github/blob/HEAD/security.md
-
-[contributing]: https://github.com/micromark/.github/blob/HEAD/contributing.md
-
-[support]: https://github.com/micromark/.github/blob/HEAD/support.md
-
-[coc]: https://github.com/micromark/.github/blob/HEAD/code-of-conduct.md
-
------------
-
-The following npm package may be included in this product:
-
- - micromark-util-chunked@1.0.0
-
-This package contains the following license and notice below:
-
-# micromark-util-chunked
-
-[![Build][build-badge]][build]
-[![Coverage][coverage-badge]][coverage]
-[![Downloads][downloads-badge]][downloads]
-[![Size][bundle-size-badge]][bundle-size]
-[![Sponsors][sponsors-badge]][opencollective]
-[![Backers][backers-badge]][opencollective]
-[![Chat][chat-badge]][chat]
-
-micromark utility to splice and push with giant arrays.
-
-## Contents
-
-*   [Install](#install)
-*   [Use](#use)
-*   [API](#api)
-    *   [`push(list, items)`](#pushlist-items)
-    *   [`splice(list, start, remove, items)`](#splicelist-start-remove-items)
-*   [Security](#security)
-*   [Contribute](#contribute)
-*   [License](#license)
-
-## Install
-
-[npm][]:
-
-```sh
-npm install micromark-util-chunked
-```
-
-## Use
-
-```js
-import {push, splice} from 'micromark-util-chunked'
-
-// …
-
-nextEvents = push(nextEvents, [
-  ['enter', events[open][1], context],
-  ['exit', events[open][1], context]
-])
-
-// …
-
-splice(events, open - 1, index - open + 3, nextEvents)
-
-// …
-```
-
-## API
-
-This module exports the following identifiers: `push`, `splice`.
-There is no default export.
-
-### `push(list, items)`
-
-Append `items` (an array) at the end of `list` (another array).
-When `list` was empty, returns `items` instead.
-
-This prevents a potentially expensive operation when `list` is empty,
-and adds items in batches to prevent V8 from hanging.
-
-###### Parameters
-
-*   `list` (`unknown[]`) — List to operate on
-*   `items` (`unknown[]`) — Items to add to `list`
-
-###### Returns
-
-`list` or `items`
-
-### `splice(list, start, remove, items)`
-
-Like `Array#splice`, but smarter for giant arrays.
-
-`Array#splice` takes all items to be inserted as individual argument which
-causes a stack overflow in V8 when trying to insert 100k items for instance.
-
-Otherwise, this does not return the removed items, and takes `items` as an
-array instead of rest parameters.
-
-###### Parameters
-
-*   `list` (`unknown[]`) — List to operate on
-*   `start` (`number`) — Index to remove/insert at (can be negative)
-*   `remove` (`number`) — Number of items to remove
-*   `items` (`unknown[]`) — Items to inject into `list`
-
-###### Returns
-
-`void`
-
-## Security
-
-See [`security.md`][securitymd] in [`micromark/.github`][health] for how to
-submit a security report.
-
-## Contribute
-
-See [`contributing.md`][contributing] in [`micromark/.github`][health] for ways
-to get started.
-See [`support.md`][support] for ways to get help.
-
-This project has a [code of conduct][coc].
-By interacting with this repository, organisation, or community you agree to
-abide by its terms.
-
-## License
-
-[MIT][license] © [Titus Wormer][author]
-
-<!-- Definitions -->
-
-[build-badge]: https://github.com/micromark/micromark/workflows/main/badge.svg
-
-[build]: https://github.com/micromark/micromark/actions
-
-[coverage-badge]: https://img.shields.io/codecov/c/github/micromark/micromark.svg
-
-[coverage]: https://codecov.io/github/micromark/micromark
-
-[downloads-badge]: https://img.shields.io/npm/dm/micromark-util-chunked.svg
-
-[downloads]: https://www.npmjs.com/package/micromark-util-chunked
-
-[bundle-size-badge]: https://img.shields.io/bundlephobia/minzip/micromark-util-chunked.svg
-
-[bundle-size]: https://bundlephobia.com/result?p=micromark-util-chunked
-
-[sponsors-badge]: https://opencollective.com/unified/sponsors/badge.svg
-
-[backers-badge]: https://opencollective.com/unified/backers/badge.svg
-
-[opencollective]: https://opencollective.com/unified
-
-[npm]: https://docs.npmjs.com/cli/install
-
-[chat-badge]: https://img.shields.io/badge/chat-discussions-success.svg
-
-[chat]: https://github.com/micromark/micromark/discussions
-
-[license]: https://github.com/micromark/micromark/blob/main/license
-
-[author]: https://wooorm.com
-
-[health]: https://github.com/micromark/.github
-
-[securitymd]: https://github.com/micromark/.github/blob/HEAD/security.md
-
-[contributing]: https://github.com/micromark/.github/blob/HEAD/contributing.md
-
-[support]: https://github.com/micromark/.github/blob/HEAD/support.md
-
-[coc]: https://github.com/micromark/.github/blob/HEAD/code-of-conduct.md
-
------------
-
-The following npm package may be included in this product:
-
- - micromark-util-classify-character@1.0.0
-
-This package contains the following license and notice below:
-
-# micromark-util-classify-character
-
-[![Build][build-badge]][build]
-[![Coverage][coverage-badge]][coverage]
-[![Downloads][downloads-badge]][downloads]
-[![Size][bundle-size-badge]][bundle-size]
-[![Sponsors][sponsors-badge]][opencollective]
-[![Backers][backers-badge]][opencollective]
-[![Chat][chat-badge]][chat]
-
-micromark utility to classify whether a character is whitespace or punctuation.
-
-## Contents
-
-*   [Install](#install)
-*   [Use](#use)
-*   [API](#api)
-    *   [`classifyCharacter(code)`](#classifycharactercode)
-*   [Security](#security)
-*   [Contribute](#contribute)
-*   [License](#license)
-
-## Install
-
-[npm][]:
-
-```sh
-npm install micromark-util-classify-character
-```
-
-## Use
-
-```js
-/** @type {Tokenizer} */
-function tokenizeAttention(effects, ok) {
-  return start
-
-  // …
-
-  /** @type {State} */
-  function sequence(code) {
-    if (code === marker) {
-      // …
-    }
-
-    const token = effects.exit('attentionSequence')
-    const after = classifyCharacter(code)
-    const open =
-      !after || (after === constants.characterGroupPunctuation && before)
-    const close =
-      !before || (before === constants.characterGroupPunctuation && after)
-    // …
-  }
-
-  // …
-}
-```
-
-## API
-
-This module exports the following identifiers: `classifyCharacter`.
-There is no default export.
-
-### `classifyCharacter(code)`
-
-Classify whether a
-[character code](https://github.com/micromark/micromark#preprocess)
-represents whitespace, punctuation, or
-something else.
-Used for attention (emphasis, strong), whose sequences can open or close based
-on the class of surrounding characters.
-
-Note that eof (`null`) is seen as whitespace.
-
-###### Returns
-
-`constants.characterGroupWhitespace`, `constants.characterGroupPunctuation`,
-or `undefined.`
-
-## Security
-
-See [`security.md`][securitymd] in [`micromark/.github`][health] for how to
-submit a security report.
-
-## Contribute
-
-See [`contributing.md`][contributing] in [`micromark/.github`][health] for ways
-to get started.
-See [`support.md`][support] for ways to get help.
-
-This project has a [code of conduct][coc].
-By interacting with this repository, organisation, or community you agree to
-abide by its terms.
-
-## License
-
-[MIT][license] © [Titus Wormer][author]
-
-<!-- Definitions -->
-
-[build-badge]: https://github.com/micromark/micromark/workflows/main/badge.svg
-
-[build]: https://github.com/micromark/micromark/actions
-
-[coverage-badge]: https://img.shields.io/codecov/c/github/micromark/micromark.svg
-
-[coverage]: https://codecov.io/github/micromark/micromark
-
-[downloads-badge]: https://img.shields.io/npm/dm/micromark-util-classify-character.svg
-
-[downloads]: https://www.npmjs.com/package/micromark-util-classify-character
-
-[bundle-size-badge]: https://img.shields.io/bundlephobia/minzip/micromark-util-classify-character.svg
-
-[bundle-size]: https://bundlephobia.com/result?p=micromark-util-classify-character
-
-[sponsors-badge]: https://opencollective.com/unified/sponsors/badge.svg
-
-[backers-badge]: https://opencollective.com/unified/backers/badge.svg
-
-[opencollective]: https://opencollective.com/unified
-
-[npm]: https://docs.npmjs.com/cli/install
-
-[chat-badge]: https://img.shields.io/badge/chat-discussions-success.svg
-
-[chat]: https://github.com/micromark/micromark/discussions
-
-[license]: https://github.com/micromark/micromark/blob/main/license
-
-[author]: https://wooorm.com
-
-[health]: https://github.com/micromark/.github
-
-[securitymd]: https://github.com/micromark/.github/blob/HEAD/security.md
-
-[contributing]: https://github.com/micromark/.github/blob/HEAD/contributing.md
-
-[support]: https://github.com/micromark/.github/blob/HEAD/support.md
-
-[coc]: https://github.com/micromark/.github/blob/HEAD/code-of-conduct.md
-
------------
-
-The following npm package may be included in this product:
-
- - micromark-util-combine-extensions@1.0.0
-
-This package contains the following license and notice below:
-
-# micromark-util-combine-extensions
-
-[![Build][build-badge]][build]
-[![Coverage][coverage-badge]][coverage]
-[![Downloads][downloads-badge]][downloads]
-[![Size][bundle-size-badge]][bundle-size]
-[![Sponsors][sponsors-badge]][opencollective]
-[![Backers][backers-badge]][opencollective]
-[![Chat][chat-badge]][chat]
-
-micromark utility to combine [syntax][] or [html][] extensions.
-
-## Contents
-
-*   [Install](#install)
-*   [Use](#use)
-*   [API](#api)
-    *   [`combineExtensions(extensions)`](#combineextensionsextensions)
-    *   [`combineHtmlExtensions(htmlExtensions)`](#combinehtmlextensionshtmlextensions)
-*   [Security](#security)
-*   [Contribute](#contribute)
-*   [License](#license)
-
-## Install
-
-[npm][]:
-
-```sh
-npm install micromark-util-combine-extensions
-```
-
-## Use
-
-```js
-import {gfmAutolinkLiteral} from 'micromark-extension-gfm-autolink-literal'
-import {gfmStrikethrough} from 'micromark-extension-gfm-strikethrough'
-import {gfmTable} from 'micromark-extension-gfm-table'
-import {gfmTaskListItem} from 'micromark-extension-gfm-task-list-item'
-import {combineExtensions} from 'micromark-util-combine-extensions'
-
-const gfm = combineExtensions([gfmAutolinkLiteral, gfmStrikethrough(), gfmTable, gfmTaskListItem])
-```
-
-## API
-
-This module exports the following identifiers: `combineExtensions`,
-`combineHtmlExtensions`.
-There is no default export.
-
-### `combineExtensions(extensions)`
-
-Combine several syntax extensions into one.
-
-###### Parameters
-
-*   `extensions` (`Extension[]`) — List of syntax extensions
-
-###### Returns
-
-A single combined extension (`Extension`).
-
-### `combineHtmlExtensions(htmlExtensions)`
-
-Combine several html extensions into one.
-
-###### Parameters
-
-*   `htmlExtensions` (`HtmlExtension[]`) — List of html extensions
-
-###### Returns
-
-A single combined html extension (`HtmlExtension`).
-
-## Security
-
-See [`security.md`][securitymd] in [`micromark/.github`][health] for how to
-submit a security report.
-
-## Contribute
-
-See [`contributing.md`][contributing] in [`micromark/.github`][health] for ways
-to get started.
-See [`support.md`][support] for ways to get help.
-
-This project has a [code of conduct][coc].
-By interacting with this repository, organisation, or community you agree to
-abide by its terms.
-
-## License
-
-[MIT][license] © [Titus Wormer][author]
-
-<!-- Definitions -->
-
-[build-badge]: https://github.com/micromark/micromark/workflows/main/badge.svg
-
-[build]: https://github.com/micromark/micromark/actions
-
-[coverage-badge]: https://img.shields.io/codecov/c/github/micromark/micromark.svg
-
-[coverage]: https://codecov.io/github/micromark/micromark
-
-[downloads-badge]: https://img.shields.io/npm/dm/micromark-util-combine-extensions.svg
-
-[downloads]: https://www.npmjs.com/package/micromark-util-combine-extensions
-
-[bundle-size-badge]: https://img.shields.io/bundlephobia/minzip/micromark-util-combine-extensions.svg
-
-[bundle-size]: https://bundlephobia.com/result?p=micromark-util-combine-extensions
-
-[sponsors-badge]: https://opencollective.com/unified/sponsors/badge.svg
-
-[backers-badge]: https://opencollective.com/unified/backers/badge.svg
-
-[opencollective]: https://opencollective.com/unified
-
-[npm]: https://docs.npmjs.com/cli/install
-
-[chat-badge]: https://img.shields.io/badge/chat-discussions-success.svg
-
-[chat]: https://github.com/micromark/micromark/discussions
-
-[license]: https://github.com/micromark/micromark/blob/main/license
-
-[author]: https://wooorm.com
-
-[health]: https://github.com/micromark/.github
-
-[securitymd]: https://github.com/micromark/.github/blob/HEAD/security.md
-
-[contributing]: https://github.com/micromark/.github/blob/HEAD/contributing.md
-
-[support]: https://github.com/micromark/.github/blob/HEAD/support.md
-
-[coc]: https://github.com/micromark/.github/blob/HEAD/code-of-conduct.md
-
-[syntax]: https://github.com/micromark/micromark#syntaxextension
-
-[html]: https://github.com/micromark/micromark#htmlextension
-
------------
-
-The following npm package may be included in this product:
-
- - micromark-util-decode-numeric-character-reference@1.0.0
-
-This package contains the following license and notice below:
-
-# micromark-util-decode-numeric-character-reference
-
-[![Build][build-badge]][build]
-[![Coverage][coverage-badge]][coverage]
-[![Downloads][downloads-badge]][downloads]
-[![Size][bundle-size-badge]][bundle-size]
-[![Sponsors][sponsors-badge]][opencollective]
-[![Backers][backers-badge]][opencollective]
-[![Chat][chat-badge]][chat]
-
-micromark utility to decode numeric character references.
-
-## Contents
-
-*   [Install](#install)
-*   [Use](#use)
-*   [API](#api)
-    *   [`decodeNumericCharacterReference(value)`](#decodenumericcharacterreferencevalue)
-*   [Security](#security)
-*   [Contribute](#contribute)
-*   [License](#license)
-
-## Install
-
-[npm][]:
-
-```sh
-npm install micromark-util-decode-numeric-character-reference
-```
-
-## Use
-
-```js
-import {decodeNumericCharacterReference} from 'micromark-util-decode-numeric-character-reference'
-
-decodeNumericCharacterReference('41', 16) // 'A'
-decodeNumericCharacterReference('65', 10) // 'A'
-decodeNumericCharacterReference('A', 16) // '\n'
-decodeNumericCharacterReference('7F', 16) // '�' - Control
-decodeNumericCharacterReference('110000', 16) // '�' - Out of range
-```
-
-## API
-
-This module exports the following identifiers:
-`decodeNumericCharacterReference`.
-There is no default export.
-
-### `decodeNumericCharacterReference(value)`
-
-Sort of like `String.fromCharCode(Number.parseInt(value, base))`,
-but makes non-characters and control characters safe.
-
-###### Parameters
-
-*   `value` (`string`) — Value to decode.
-*   `base` (`number`, probably `10` or `16`) — Numeric base.
-
-###### Returns
-
-`string` — Character code.
-
-## Security
-
-See [`security.md`][securitymd] in [`micromark/.github`][health] for how to
-submit a security report.
-
-## Contribute
-
-See [`contributing.md`][contributing] in [`micromark/.github`][health] for ways
-to get started.
-See [`support.md`][support] for ways to get help.
-
-This project has a [code of conduct][coc].
-By interacting with this repository, organisation, or community you agree to
-abide by its terms.
-
-## License
-
-[MIT][license] © [Titus Wormer][author]
-
-<!-- Definitions -->
-
-[build-badge]: https://github.com/micromark/micromark/workflows/main/badge.svg
-
-[build]: https://github.com/micromark/micromark/actions
-
-[coverage-badge]: https://img.shields.io/codecov/c/github/micromark/micromark.svg
-
-[coverage]: https://codecov.io/github/micromark/micromark
-
-[downloads-badge]: https://img.shields.io/npm/dm/micromark-util-normalize-identifier.svg
-
-[downloads]: https://www.npmjs.com/package/micromark-util-normalize-identifier
-
-[bundle-size-badge]: https://img.shields.io/bundlephobia/minzip/micromark-util-normalize-identifier.svg
-
-[bundle-size]: https://bundlephobia.com/result?p=micromark-util-normalize-identifier
-
-[sponsors-badge]: https://opencollective.com/unified/sponsors/badge.svg
-
-[backers-badge]: https://opencollective.com/unified/backers/badge.svg
-
-[opencollective]: https://opencollective.com/unified
-
-[npm]: https://docs.npmjs.com/cli/install
-
-[chat-badge]: https://img.shields.io/badge/chat-discussions-success.svg
-
-[chat]: https://github.com/micromark/micromark/discussions
-
-[license]: https://github.com/micromark/micromark/blob/main/license
-
-[author]: https://wooorm.com
-
-[health]: https://github.com/micromark/.github
-
-[securitymd]: https://github.com/micromark/.github/blob/HEAD/security.md
-
-[contributing]: https://github.com/micromark/.github/blob/HEAD/contributing.md
-
-[support]: https://github.com/micromark/.github/blob/HEAD/support.md
-
-[coc]: https://github.com/micromark/.github/blob/HEAD/code-of-conduct.md
-
------------
-
-The following npm package may be included in this product:
-
- - micromark-util-decode-string@1.0.2
-
-This package contains the following license and notice below:
-
-# micromark-util-decode-string
-
-[![Build][build-badge]][build]
-[![Coverage][coverage-badge]][coverage]
-[![Downloads][downloads-badge]][downloads]
-[![Size][bundle-size-badge]][bundle-size]
-[![Sponsors][sponsors-badge]][opencollective]
-[![Backers][backers-badge]][opencollective]
-[![Chat][chat-badge]][chat]
-
-micromark utility to decode markdown strings.
-
-## Contents
-
-*   [Install](#install)
-*   [Use](#use)
-*   [API](#api)
-    *   [`decodeString(value)`](#decodestringvalue)
-*   [Security](#security)
-*   [Contribute](#contribute)
-*   [License](#license)
-
-## Install
-
-[npm][]:
-
-```sh
-npm install micromark-util-decode-string
-```
-
-## Use
-
-```js
-import {decodeString} from 'micromark-util-decode-string'
-
-decodeString('a &semi; b') // 'a ; b'
-decodeString('a \\; b') // 'a ; b'
-decodeString('a ; b') // 'a ; b'
-```
-
-## API
-
-This module exports the following identifiers: `decodeString`.
-There is no default export.
-
-### `decodeString(value)`
-
-micromark utility to decode markdown strings (which occur in places such as
-fenced code info strings, destinations, labels, and titles).
-The “string” content type allows character escapes and -references.
-This decodes those.
-
-###### Parameters
-
-*   `value` (`string`) — Value to decode.
-
-###### Returns
-
-`string` — Decoded value.
-
-## Security
-
-See [`security.md`][securitymd] in [`micromark/.github`][health] for how to
-submit a security report.
-
-## Contribute
-
-See [`contributing.md`][contributing] in [`micromark/.github`][health] for ways
-to get started.
-See [`support.md`][support] for ways to get help.
-
-This project has a [code of conduct][coc].
-By interacting with this repository, organisation, or community you agree to
-abide by its terms.
-
-## License
-
-[MIT][license] © [Titus Wormer][author]
-
-<!-- Definitions -->
-
-[build-badge]: https://github.com/micromark/micromark/workflows/main/badge.svg
-
-[build]: https://github.com/micromark/micromark/actions
-
-[coverage-badge]: https://img.shields.io/codecov/c/github/micromark/micromark.svg
-
-[coverage]: https://codecov.io/github/micromark/micromark
-
-[downloads-badge]: https://img.shields.io/npm/dm/micromark-util-normalize-identifier.svg
-
-[downloads]: https://www.npmjs.com/package/micromark-util-normalize-identifier
-
-[bundle-size-badge]: https://img.shields.io/bundlephobia/minzip/micromark-util-normalize-identifier.svg
-
-[bundle-size]: https://bundlephobia.com/result?p=micromark-util-normalize-identifier
-
-[sponsors-badge]: https://opencollective.com/unified/sponsors/badge.svg
-
-[backers-badge]: https://opencollective.com/unified/backers/badge.svg
-
-[opencollective]: https://opencollective.com/unified
-
-[npm]: https://docs.npmjs.com/cli/install
-
-[chat-badge]: https://img.shields.io/badge/chat-discussions-success.svg
-
-[chat]: https://github.com/micromark/micromark/discussions
-
-[license]: https://github.com/micromark/micromark/blob/main/license
-
-[author]: https://wooorm.com
-
-[health]: https://github.com/micromark/.github
-
-[securitymd]: https://github.com/micromark/.github/blob/HEAD/security.md
-
-[contributing]: https://github.com/micromark/.github/blob/HEAD/contributing.md
-
-[support]: https://github.com/micromark/.github/blob/HEAD/support.md
-
-[coc]: https://github.com/micromark/.github/blob/HEAD/code-of-conduct.md
-
------------
-
-The following npm package may be included in this product:
-
- - micromark-util-encode@1.0.1
-
-This package contains the following license and notice below:
-
-# micromark-util-encode
-
-[![Build][build-badge]][build]
-[![Coverage][coverage-badge]][coverage]
-[![Downloads][downloads-badge]][downloads]
-[![Size][bundle-size-badge]][bundle-size]
-[![Sponsors][sponsors-badge]][opencollective]
-[![Backers][backers-badge]][opencollective]
-[![Chat][chat-badge]][chat]
-
-micromark utility to encode dangerous html characters.
-
-## Contents
-
-*   [Install](#install)
-*   [Use](#use)
-*   [API](#api)
-    *   [`encode(value)`](#encodevalue)
-*   [Security](#security)
-*   [Contribute](#contribute)
-*   [License](#license)
-
-## Install
-
-[npm][]:
-
-```sh
-npm install micromark-util-encode
-```
-
-## Use
-
-```js
-import {encode} from 'micromark-util-encode'
-
-encode('<3') // '&lt;3'
-```
-
-## API
-
-This module exports the following identifiers: `encode`.
-There is no default export.
-
-### `encode(value)`
-
-Encode only the dangerous HTML characters.
-
-This ensures that certain characters which have special meaning in HTML are
-dealt with.
-Technically, we can skip `>` and `"` in many cases, but CM includes them.
-
-###### Parameters
-
-*   `value` (`string`) — Value to encode.
-
-###### Returns
-
-`string` — Encoded value.
-
-## Security
-
-See [`security.md`][securitymd] in [`micromark/.github`][health] for how to
-submit a security report.
-
-## Contribute
-
-See [`contributing.md`][contributing] in [`micromark/.github`][health] for ways
-to get started.
-See [`support.md`][support] for ways to get help.
-
-This project has a [code of conduct][coc].
-By interacting with this repository, organisation, or community you agree to
-abide by its terms.
-
-## License
-
-[MIT][license] © [Titus Wormer][author]
-
-<!-- Definitions -->
-
-[build-badge]: https://github.com/micromark/micromark/workflows/main/badge.svg
-
-[build]: https://github.com/micromark/micromark/actions
-
-[coverage-badge]: https://img.shields.io/codecov/c/github/micromark/micromark.svg
-
-[coverage]: https://codecov.io/github/micromark/micromark
-
-[downloads-badge]: https://img.shields.io/npm/dm/micromark-util-encode.svg
-
-[downloads]: https://www.npmjs.com/package/micromark-util-encode
-
-[bundle-size-badge]: https://img.shields.io/bundlephobia/minzip/micromark-util-encode.svg
-
-[bundle-size]: https://bundlephobia.com/result?p=micromark-util-encode
-
-[sponsors-badge]: https://opencollective.com/unified/sponsors/badge.svg
-
-[backers-badge]: https://opencollective.com/unified/backers/badge.svg
-
-[opencollective]: https://opencollective.com/unified
-
-[npm]: https://docs.npmjs.com/cli/install
-
-[chat-badge]: https://img.shields.io/badge/chat-discussions-success.svg
-
-[chat]: https://github.com/micromark/micromark/discussions
-
-[license]: https://github.com/micromark/micromark/blob/main/license
-
-[author]: https://wooorm.com
-
-[health]: https://github.com/micromark/.github
-
-[securitymd]: https://github.com/micromark/.github/blob/HEAD/security.md
-
-[contributing]: https://github.com/micromark/.github/blob/HEAD/contributing.md
-
-[support]: https://github.com/micromark/.github/blob/HEAD/support.md
-
-[coc]: https://github.com/micromark/.github/blob/HEAD/code-of-conduct.md
-
------------
-
-The following npm package may be included in this product:
-
- - micromark-util-html-tag-name@1.1.0
-
-This package contains the following license and notice below:
-
-# micromark-util-html-tag-name
-
-[![Build][build-badge]][build]
-[![Coverage][coverage-badge]][coverage]
-[![Downloads][downloads-badge]][downloads]
-[![Size][bundle-size-badge]][bundle-size]
-[![Sponsors][sponsors-badge]][opencollective]
-[![Backers][backers-badge]][opencollective]
-[![Chat][chat-badge]][chat]
-
-micromark utility with list of html tag names.
-
-## Contents
-
-*   [Install](#install)
-*   [Use](#use)
-*   [API](#api)
-    *   [`htmlBlockNames`](#htmlblocknames)
-    *   [`htmlRawNames`](#htmlrawnames)
-*   [Security](#security)
-*   [Contribute](#contribute)
-*   [License](#license)
-
-## Install
-
-This package is [ESM only][esm].
-In Node.js (version 12.20+, 14.14+, 16.0+, 18.0+), install with [npm][]:
-
-```sh
-npm install micromark-util-html-tag-name
-```
-
-In Deno with [`esm.sh`][esmsh]:
-
-```js
-import {htmlBlockNames, htmlRawNames} from 'https://esm.sh/micromark-util-html-tag-name@1'
-```
-
-In browsers with [`esm.sh`][esmsh]:
-
-```html
-<script type="module">
-  import {htmlBlockNames, htmlRawNames} from 'https://esm.sh/micromark-util-html-tag-name@1?bundle'
-</script>
-```
-
-## Use
-
-```js
-import {htmlBlockNames, htmlRawNames} from 'micromark-util-html-tag-name'
-
-console.log(htmlBlockNames) // ['address', 'article', …]
-console.log(htmlRawNames) // ['pre', 'script', …]
-```
-
-## API
-
-This module exports the following identifiers: `htmlBlockNames`,
-`htmlRawNames`.
-There is no default export.
-
-### `htmlBlockNames`
-
-List of lowercase HTML tag names (`Array<string>`) which when parsing HTML
-(flow), result in more relaxed rules (condition 6): because they are known
-blocks, the HTML-like syntax doesn’t have to be strictly parsed.
-For tag names not in this list, a more strict algorithm (condition 7) is used
-to detect whether the HTML-like syntax is seen as HTML (flow) or not.
-
-This is copied from: <https://spec.commonmark.org/0.30/#html-blocks>.
-
-### `htmlRawNames`
-
-List of lowercase HTML tag names (`Array<string>`) which when parsing HTML
-(flow), result in HTML that can include lines w/o exiting, until a closing tag
-also in this list is found (condition 1).
-
-This is copied from:
-<https://spec.commonmark.org/0.30/#html-blocks>.
-
-Note that `textarea` was added in `CommonMark@0.30`.
-
-## Security
-
-See [`security.md`][securitymd] in [`micromark/.github`][health] for how to
-submit a security report.
-
-## Contribute
-
-See [`contributing.md`][contributing] in [`micromark/.github`][health] for ways
-to get started.
-See [`support.md`][support] for ways to get help.
-
-This project has a [code of conduct][coc].
-By interacting with this repository, organisation, or community you agree to
-abide by its terms.
-
-## License
-
-[MIT][license] © [Titus Wormer][author]
-
-<!-- Definitions -->
-
-[build-badge]: https://github.com/micromark/micromark/workflows/main/badge.svg
-
-[build]: https://github.com/micromark/micromark/actions
-
-[coverage-badge]: https://img.shields.io/codecov/c/github/micromark/micromark.svg
-
-[coverage]: https://codecov.io/github/micromark/micromark
-
-[downloads-badge]: https://img.shields.io/npm/dm/micromark-util-html-tag-name.svg
-
-[downloads]: https://www.npmjs.com/package/micromark-util-html-tag-name
-
-[bundle-size-badge]: https://img.shields.io/bundlephobia/minzip/micromark-util-html-tag-name.svg
-
-[bundle-size]: https://bundlephobia.com/result?p=micromark-util-html-tag-name
-
-[sponsors-badge]: https://opencollective.com/unified/sponsors/badge.svg
-
-[backers-badge]: https://opencollective.com/unified/backers/badge.svg
-
-[opencollective]: https://opencollective.com/unified
-
-[npm]: https://docs.npmjs.com/cli/install
-
-[esm]: https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c
-
-[esmsh]: https://esm.sh
-
-[chat-badge]: https://img.shields.io/badge/chat-discussions-success.svg
-
-[chat]: https://github.com/micromark/micromark/discussions
-
-[license]: https://github.com/micromark/micromark/blob/main/license
-
-[author]: https://wooorm.com
-
-[health]: https://github.com/micromark/.github
-
-[securitymd]: https://github.com/micromark/.github/blob/HEAD/security.md
-
-[contributing]: https://github.com/micromark/.github/blob/HEAD/contributing.md
-
-[support]: https://github.com/micromark/.github/blob/HEAD/support.md
-
-[coc]: https://github.com/micromark/.github/blob/HEAD/code-of-conduct.md
-
------------
-
-The following npm package may be included in this product:
-
- - micromark-util-normalize-identifier@1.0.0
-
-This package contains the following license and notice below:
-
-# micromark-util-normalize-identifier
-
-[![Build][build-badge]][build]
-[![Coverage][coverage-badge]][coverage]
-[![Downloads][downloads-badge]][downloads]
-[![Size][bundle-size-badge]][bundle-size]
-[![Sponsors][sponsors-badge]][opencollective]
-[![Backers][backers-badge]][opencollective]
-[![Chat][chat-badge]][chat]
-
-micromark utility normalize identifiers (as found in references, definitions).
-
-## Contents
-
-*   [Install](#install)
-*   [Use](#use)
-*   [API](#api)
-    *   [`normalizeIdentifier(value)`](#normalizeidentifiervalue)
-*   [Security](#security)
-*   [Contribute](#contribute)
-*   [License](#license)
-
-## Install
-
-[npm][]:
-
-```sh
-npm install micromark-util-normalize-identifier
-```
-
-## Use
-
-```js
-import {normalizeIdentifier} from 'micromark-util-normalize-identifier'
-
-normalizeIdentifier(' a ') // 'A'
-normalizeIdentifier('a\t\r\nb') // 'A B'
-normalizeIdentifier('ТОЛПОЙ') // 'ТОЛПОЙ'
-normalizeIdentifier('Толпой') // 'ТОЛПОЙ'
-```
-
-## API
-
-This module exports the following identifiers: `normalizeIdentifier`.
-There is no default export.
-
-### `normalizeIdentifier(value)`
-
-Normalize an identifier (such as used in definitions).
-Collapse Markdown whitespace, trim, and then lower- and uppercase.
-
-Some characters are considered “uppercase”, such as U+03F4 (`ϴ`), but if their
-lowercase counterpart (U+03B8 (`θ`)) is uppercased will result in a different
-uppercase character (U+0398 (`Θ`)).
-Hence, to get that form, we perform both lower- and uppercase.
-
-Using uppercase last makes sure keys will not interact with default prototypal
-methods: no method is uppercase.
-
-###### Parameters
-
-*   `value` (`string`) — Identifier to normalize.
-
-###### Returns
-
-`string` — Normalized value.
-
-## Security
-
-See [`security.md`][securitymd] in [`micromark/.github`][health] for how to
-submit a security report.
-
-## Contribute
-
-See [`contributing.md`][contributing] in [`micromark/.github`][health] for ways
-to get started.
-See [`support.md`][support] for ways to get help.
-
-This project has a [code of conduct][coc].
-By interacting with this repository, organisation, or community you agree to
-abide by its terms.
-
-## License
-
-[MIT][license] © [Titus Wormer][author]
-
-<!-- Definitions -->
-
-[build-badge]: https://github.com/micromark/micromark/workflows/main/badge.svg
-
-[build]: https://github.com/micromark/micromark/actions
-
-[coverage-badge]: https://img.shields.io/codecov/c/github/micromark/micromark.svg
-
-[coverage]: https://codecov.io/github/micromark/micromark
-
-[downloads-badge]: https://img.shields.io/npm/dm/micromark-util-normalize-identifier.svg
-
-[downloads]: https://www.npmjs.com/package/micromark-util-normalize-identifier
-
-[bundle-size-badge]: https://img.shields.io/bundlephobia/minzip/micromark-util-normalize-identifier.svg
-
-[bundle-size]: https://bundlephobia.com/result?p=micromark-util-normalize-identifier
-
-[sponsors-badge]: https://opencollective.com/unified/sponsors/badge.svg
-
-[backers-badge]: https://opencollective.com/unified/backers/badge.svg
-
-[opencollective]: https://opencollective.com/unified
-
-[npm]: https://docs.npmjs.com/cli/install
-
-[chat-badge]: https://img.shields.io/badge/chat-discussions-success.svg
-
-[chat]: https://github.com/micromark/micromark/discussions
-
-[license]: https://github.com/micromark/micromark/blob/main/license
-
-[author]: https://wooorm.com
-
-[health]: https://github.com/micromark/.github
-
-[securitymd]: https://github.com/micromark/.github/blob/HEAD/security.md
-
-[contributing]: https://github.com/micromark/.github/blob/HEAD/contributing.md
-
-[support]: https://github.com/micromark/.github/blob/HEAD/support.md
-
-[coc]: https://github.com/micromark/.github/blob/HEAD/code-of-conduct.md
-
------------
-
-The following npm package may be included in this product:
-
- - micromark-util-resolve-all@1.0.0
-
-This package contains the following license and notice below:
-
-# micromark-util-resolve-all
-
-[![Build][build-badge]][build]
-[![Coverage][coverage-badge]][coverage]
-[![Downloads][downloads-badge]][downloads]
-[![Size][bundle-size-badge]][bundle-size]
-[![Sponsors][sponsors-badge]][opencollective]
-[![Backers][backers-badge]][opencollective]
-[![Chat][chat-badge]][chat]
-
-micromark utility to resolve subtokens.
-
-[Resolvers][resolver] are functions that take events and manipulate them.
-This is needed for example because media (links, images) and attention (strong,
-italic) aren’t parsed left-to-right.
-Instead, their openings and closings are parsed, and when done, their openings
-and closings are matched, and left overs are turned into plain text.
-Because media and attention can’t overlap, we need to perform that operation
-when one closing matches an opening, too.
-
-## Contents
-
-*   [Install](#install)
-*   [Use](#use)
-*   [API](#api)
-    *   [`resolveAll(constructs, events, context)`](#resolveallconstructs-events-context)
-*   [Security](#security)
-*   [Contribute](#contribute)
-*   [License](#license)
-
-## Install
-
-[npm][]:
-
-```sh
-npm install micromark-util-resolve-all
-```
-
-## Use
-
-```js
-import {push} from 'micromark-util-chunked'
-import {resolveAll} from 'micromark-util-resolve-all'
-
-/**
- * @type {Resolver}
- */
-function resolveAllAttention(events, context) {
-  // …
-
-  // Walk through all events.
-  while (++index < events.length) {
-    // Find a token that can close.
-    if (
-      events[index][0] === 'enter' &&
-      events[index][1].type === 'attentionSequence' &&
-      events[index][1]._close
-    ) {
-      open = index
-
-      // Now walk back to find an opener.
-      while (open--) {
-        // Find a token that can open the closer.
-        if (
-          // …
-        ) {
-          // …
-
-          // Opening.
-          nextEvents = push(nextEvents, [
-            // …
-          ])
-
-          // Between.
-          nextEvents = push(
-            nextEvents,
-            resolveAll(
-              context.parser.constructs.insideSpan.null,
-              events.slice(open + 1, index),
-              context
-            )
-          )
-
-          // Closing.
-          nextEvents = push(nextEvents, [
-            // …
-          ])
-
-          // …
-        }
-      }
-    }
-  }
-
-  // …
-}
-```
-
-## API
-
-This module exports the following identifiers: `resolveAll`.
-There is no default export.
-
-### `resolveAll(constructs, events, context)`
-
-Call all `resolveAll`s in `constructs`.
-
-###### Parameters
-
-*   `constructs` (`Construct[]`) — List of constructs, optionally with
-    `resolveAll`s
-*   `events` (`Event[]`) — List of events
-*   `context` (`TokenizeContext`) — Context used by `tokenize`
-
-###### Returns
-
-`Events[]` — Changed events.
-
-## Security
-
-See [`security.md`][securitymd] in [`micromark/.github`][health] for how to
-submit a security report.
-
-## Contribute
-
-See [`contributing.md`][contributing] in [`micromark/.github`][health] for ways
-to get started.
-See [`support.md`][support] for ways to get help.
-
-This project has a [code of conduct][coc].
-By interacting with this repository, organisation, or community you agree to
-abide by its terms.
-
-## License
-
-[MIT][license] © [Titus Wormer][author]
-
-<!-- Definitions -->
-
-[build-badge]: https://github.com/micromark/micromark/workflows/main/badge.svg
-
-[build]: https://github.com/micromark/micromark/actions
-
-[coverage-badge]: https://img.shields.io/codecov/c/github/micromark/micromark.svg
-
-[coverage]: https://codecov.io/github/micromark/micromark
-
-[downloads-badge]: https://img.shields.io/npm/dm/micromark-util-resolve-all.svg
-
-[downloads]: https://www.npmjs.com/package/micromark-util-resolve-all
-
-[bundle-size-badge]: https://img.shields.io/bundlephobia/minzip/micromark-util-resolve-all.svg
-
-[bundle-size]: https://bundlephobia.com/result?p=micromark-util-resolve-all
-
-[sponsors-badge]: https://opencollective.com/unified/sponsors/badge.svg
-
-[backers-badge]: https://opencollective.com/unified/backers/badge.svg
-
-[opencollective]: https://opencollective.com/unified
-
-[npm]: https://docs.npmjs.com/cli/install
-
-[chat-badge]: https://img.shields.io/badge/chat-discussions-success.svg
-
-[chat]: https://github.com/micromark/micromark/discussions
-
-[license]: https://github.com/micromark/micromark/blob/main/license
-
-[author]: https://wooorm.com
-
-[health]: https://github.com/micromark/.github
-
-[securitymd]: https://github.com/micromark/.github/blob/HEAD/security.md
-
-[contributing]: https://github.com/micromark/.github/blob/HEAD/contributing.md
-
-[support]: https://github.com/micromark/.github/blob/HEAD/support.md
-
-[coc]: https://github.com/micromark/.github/blob/HEAD/code-of-conduct.md
-
-[resolver]: https://github.com/micromark/micromark/blob/a571c09/packages/micromark-util-types/index.js#L219
-
------------
-
-The following npm package may be included in this product:
-
- - micromark-util-sanitize-uri@1.1.0
-
-This package contains the following license and notice below:
-
-# micromark-util-sanitize-uri
-
-[![Build][build-badge]][build]
-[![Coverage][coverage-badge]][coverage]
-[![Downloads][downloads-badge]][downloads]
-[![Size][bundle-size-badge]][bundle-size]
-[![Sponsors][sponsors-badge]][opencollective]
-[![Backers][backers-badge]][opencollective]
-[![Chat][chat-badge]][chat]
-
-micromark utility to sanitize urls.
-
-## Contents
-
-*   [Install](#install)
-*   [Use](#use)
-*   [API](#api)
-    *   [`sanitizeUri(url[, pattern])`](#sanitizeuriurl-pattern)
-    *   [`normalizeUri(url[, pattern])`](#normalizeuriurl-pattern)
-*   [Security](#security)
-*   [Contribute](#contribute)
-*   [License](#license)
-
-## Install
-
-This package is [ESM only][esm].
-In Node.js (version 12.20+, 14.14+, 16.0+, 18.0+), install with [npm][]:
-
-```sh
-npm install micromark-util-sanitize-uri
-```
-
-In Deno with [`esm.sh`][esmsh]:
-
-```js
-import {sanitizeUri} from 'https://esm.sh/micromark-util-sanitize-uri@1'
-```
-
-In browsers with [`esm.sh`][esmsh]:
-
-```html
-<script type="module">
-  import {sanitizeUri} from 'https://esm.sh/micromark-util-sanitize-uri@1?bundle'
-</script>
-```
-
-## Use
-
-```js
-import {sanitizeUri} from 'micromark-util-sanitize-uri'
-
-sanitizeUri('https://example.com/a&amp;b') // 'https://example.com/a&amp;amp;b'
-sanitizeUri('https://example.com/a%b') // 'https://example.com/a%25b'
-sanitizeUri('https://example.com/a%20b') // 'https://example.com/a%20b'
-sanitizeUri('https://example.com/👍') // 'https://example.com/%F0%9F%91%8D'
-sanitizeUri('https://example.com/', /^https?$/i) // 'https://example.com/'
-sanitizeUri('javascript:alert(1)', /^https?$/i) // ''
-sanitizeUri('./example.jpg', /^https?$/i) // './example.jpg'
-sanitizeUri('#a', /^https?$/i) // '#a'
-```
-
-## API
-
-This module exports the following identifiers: `sanitizeUri`.
-There is no default export.
-
-### `sanitizeUri(url[, pattern])`
-
-Make a value safe for injection as a URL.
-
-This encodes unsafe characters with percent-encoding and skips already
-encoded sequences (see `normalizeUri` internally).
-Further unsafe characters are encoded as character references (see
-`micromark-util-encode`).
-
-A regex of allowed protocols can be given, in which case the URL is sanitized.
-For example, `/^(https?|ircs?|mailto|xmpp)$/i` can be used for `a[href]`, or
-`/^https?$/i` for `img[src]` (this is what `github.com` allows).
-If the URL includes an unknown protocol (one not matched by `protocol`, such
-as a dangerous example, `javascript:`), the value is ignored.
-
-###### Parameters
-
-*   `url` (`string`) — URI to sanitize.
-*   `pattern` (`RegExp`, optional) — Allowed protocols.
-
-###### Returns
-
-`string` — Sanitized URI.
-
-### `normalizeUri(url[, pattern])`
-
-Normalize a URL (such as used in definitions).
-
-Encode unsafe characters with percent-encoding, skipping already encoded
-sequences.
-
-###### Parameters
-
-*   `url` (`string`) — URI to normalize.
-
-###### Returns
-
-`string` — Normalized URI.
-
-## Security
-
-See [`security.md`][securitymd] in [`micromark/.github`][health] for how to
-submit a security report.
-
-## Contribute
-
-See [`contributing.md`][contributing] in [`micromark/.github`][health] for ways
-to get started.
-See [`support.md`][support] for ways to get help.
-
-This project has a [code of conduct][coc].
-By interacting with this repository, organisation, or community you agree to
-abide by its terms.
-
-## License
-
-[MIT][license] © [Titus Wormer][author]
-
-<!-- Definitions -->
-
-[build-badge]: https://github.com/micromark/micromark/workflows/main/badge.svg
-
-[build]: https://github.com/micromark/micromark/actions
-
-[coverage-badge]: https://img.shields.io/codecov/c/github/micromark/micromark.svg
-
-[coverage]: https://codecov.io/github/micromark/micromark
-
-[downloads-badge]: https://img.shields.io/npm/dm/micromark-util-sanitize-uri.svg
-
-[downloads]: https://www.npmjs.com/package/micromark-util-sanitize-uri
-
-[bundle-size-badge]: https://img.shields.io/bundlephobia/minzip/micromark-util-sanitize-uri.svg
-
-[bundle-size]: https://bundlephobia.com/result?p=micromark-util-sanitize-uri
-
-[sponsors-badge]: https://opencollective.com/unified/sponsors/badge.svg
-
-[backers-badge]: https://opencollective.com/unified/backers/badge.svg
-
-[opencollective]: https://opencollective.com/unified
-
-[npm]: https://docs.npmjs.com/cli/install
-
-[esm]: https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c
-
-[esmsh]: https://esm.sh
-
-[chat-badge]: https://img.shields.io/badge/chat-discussions-success.svg
-
-[chat]: https://github.com/micromark/micromark/discussions
-
-[license]: https://github.com/micromark/micromark/blob/main/license
-
-[author]: https://wooorm.com
-
-[health]: https://github.com/micromark/.github
-
-[securitymd]: https://github.com/micromark/.github/blob/HEAD/security.md
-
-[contributing]: https://github.com/micromark/.github/blob/HEAD/contributing.md
-
-[support]: https://github.com/micromark/.github/blob/HEAD/support.md
-
-[coc]: https://github.com/micromark/.github/blob/HEAD/code-of-conduct.md
-
------------
-
-The following npm package may be included in this product:
-
- - micromark-util-subtokenize@1.0.2
-
-This package contains the following license and notice below:
-
-# micromark-util-subtokenize
-
-[![Build][build-badge]][build]
-[![Coverage][coverage-badge]][coverage]
-[![Downloads][downloads-badge]][downloads]
-[![Size][bundle-size-badge]][bundle-size]
-[![Sponsors][sponsors-badge]][opencollective]
-[![Backers][backers-badge]][opencollective]
-[![Chat][chat-badge]][chat]
-
-micromark utility to tokenize subtokens.
-
-## Contents
-
-*   [Install](#install)
-*   [Use](#use)
-*   [API](#api)
-    *   [`subtokenize(events)`](#subtokenizeevents)
-*   [Security](#security)
-*   [Contribute](#contribute)
-*   [License](#license)
-
-## Install
-
-[npm][]:
-
-```sh
-npm install micromark-util-subtokenize
-```
-
-## Use
-
-```js
-import {subtokenize} from 'micromark-util-subtokenize'
-
-/**
- * Content is transparent: it’s parsed right now. That way, definitions are also
- * parsed right now: before text in paragraphs (specifically, media) are parsed.
- *
- * @type {Resolver}
- */
-function resolveContent(events) {
-  subtokenize(events)
-  return events
-}
-```
-
-## API
-
-This module exports the following identifiers: `subtokenize`.
-There is no default export.
-
-### `subtokenize(events)`
-
-Tokenize subcontent.
-
-###### Parameters
-
-*   `events` (`Event[]`) — List of events
-
-###### Returns
-
-`boolean` — Whether subtokens were found.
-
-## Security
-
-See [`security.md`][securitymd] in [`micromark/.github`][health] for how to
-submit a security report.
-
-## Contribute
-
-See [`contributing.md`][contributing] in [`micromark/.github`][health] for ways
-to get started.
-See [`support.md`][support] for ways to get help.
-
-This project has a [code of conduct][coc].
-By interacting with this repository, organisation, or community you agree to
-abide by its terms.
-
-## License
-
-[MIT][license] © [Titus Wormer][author]
-
-<!-- Definitions -->
-
-[build-badge]: https://github.com/micromark/micromark/workflows/main/badge.svg
-
-[build]: https://github.com/micromark/micromark/actions
-
-[coverage-badge]: https://img.shields.io/codecov/c/github/micromark/micromark.svg
-
-[coverage]: https://codecov.io/github/micromark/micromark
-
-[downloads-badge]: https://img.shields.io/npm/dm/micromark-util-subtokenize.svg
-
-[downloads]: https://www.npmjs.com/package/micromark-util-subtokenize
-
-[bundle-size-badge]: https://img.shields.io/bundlephobia/minzip/micromark-util-subtokenize.svg
-
-[bundle-size]: https://bundlephobia.com/result?p=micromark-util-subtokenize
-
-[sponsors-badge]: https://opencollective.com/unified/sponsors/badge.svg
-
-[backers-badge]: https://opencollective.com/unified/backers/badge.svg
-
-[opencollective]: https://opencollective.com/unified
-
-[npm]: https://docs.npmjs.com/cli/install
-
-[chat-badge]: https://img.shields.io/badge/chat-discussions-success.svg
-
-[chat]: https://github.com/micromark/micromark/discussions
-
-[license]: https://github.com/micromark/micromark/blob/main/license
-
-[author]: https://wooorm.com
-
-[health]: https://github.com/micromark/.github
-
-[securitymd]: https://github.com/micromark/.github/blob/HEAD/security.md
-
-[contributing]: https://github.com/micromark/.github/blob/HEAD/contributing.md
-
-[support]: https://github.com/micromark/.github/blob/HEAD/support.md
-
-[coc]: https://github.com/micromark/.github/blob/HEAD/code-of-conduct.md
-
------------
-
-The following npm package may be included in this product:
-
- - micromark-util-symbol@1.0.1
-
-This package contains the following license and notice below:
-
-# micromark-util-symbol
-
-[![Build][build-badge]][build]
-[![Coverage][coverage-badge]][coverage]
-[![Downloads][downloads-badge]][downloads]
-[![Size][bundle-size-badge]][bundle-size]
-[![Sponsors][sponsors-badge]][opencollective]
-[![Backers][backers-badge]][opencollective]
-[![Chat][chat-badge]][chat]
-
-micromark utility with symbols.
-
-It’s useful to reference these by name instead of value while developing.
-[`micromark-build`][micromark-build] compiles them away for production code.
-
-## Contents
-
-*   [Install](#install)
-*   [Use](#use)
-*   [API](#api)
-*   [Security](#security)
-*   [Contribute](#contribute)
-*   [License](#license)
-
-## Install
-
-[npm][]:
-
-```sh
-npm install micromark-util-symbol
-```
-
-## Use
-
-```js
-import {codes} from 'micromark-util-symbol/codes'
-import {constants} from 'micromark-util-symbol/constants'
-import {types} from 'micromark-util-symbol/types'
-import {values} from 'micromark-util-symbol/values'
-
-console.log(codes.atSign) // 64
-console.log(constants.characterReferenceNamedSizeMax) // 31
-console.log(types.definitionDestinationRaw) // 'definitionDestinationRaw'
-console.log(values.atSign) // '@'
-```
-
-## API
-
-This package has four entries in its export map: `micromark-util-symbol/codes`,
-`micromark-util-symbol/constants`, `micromark-util-symbol/types`,
-`micromark-util-symbol/values`.
-
-Each module exports an identifier with the same name (for example,
-`micromark-util-symbol/codes` has `codes`), which is an object mapping strings
-to other values.
-
-Take a peek at the code to learn more!
-
-## Security
-
-See [`security.md`][securitymd] in [`micromark/.github`][health] for how to
-submit a security report.
-
-## Contribute
-
-See [`contributing.md`][contributing] in [`micromark/.github`][health] for ways
-to get started.
-See [`support.md`][support] for ways to get help.
-
-This project has a [code of conduct][coc].
-By interacting with this repository, organisation, or community you agree to
-abide by its terms.
-
-## License
-
-[MIT][license] © [Titus Wormer][author]
-
-<!-- Definitions -->
-
-[build-badge]: https://github.com/micromark/micromark/workflows/main/badge.svg
-
-[build]: https://github.com/micromark/micromark/actions
-
-[coverage-badge]: https://img.shields.io/codecov/c/github/micromark/micromark.svg
-
-[coverage]: https://codecov.io/github/micromark/micromark
-
-[downloads-badge]: https://img.shields.io/npm/dm/micromark-util-symbol.svg
-
-[downloads]: https://www.npmjs.com/package/micromark-util-symbol
-
-[bundle-size-badge]: https://img.shields.io/bundlephobia/minzip/micromark-util-symbol.svg
-
-[bundle-size]: https://bundlephobia.com/result?p=micromark-util-symbol
-
-[sponsors-badge]: https://opencollective.com/unified/sponsors/badge.svg
-
-[backers-badge]: https://opencollective.com/unified/backers/badge.svg
-
-[opencollective]: https://opencollective.com/unified
-
-[npm]: https://docs.npmjs.com/cli/install
-
-[chat-badge]: https://img.shields.io/badge/chat-discussions-success.svg
-
-[chat]: https://github.com/micromark/micromark/discussions
-
-[license]: https://github.com/micromark/micromark/blob/main/license
-
-[author]: https://wooorm.com
-
-[health]: https://github.com/micromark/.github
-
-[securitymd]: https://github.com/micromark/.github/blob/HEAD/security.md
-
-[contributing]: https://github.com/micromark/.github/blob/HEAD/contributing.md
-
-[support]: https://github.com/micromark/.github/blob/HEAD/support.md
-
-[coc]: https://github.com/micromark/.github/blob/HEAD/code-of-conduct.md
-
-[micromark-build]: https://github.com/micromark/micromark/tree/main/packages/micromark-build
-
------------
-
-The following npm package may be included in this product:
-
- - micromark-util-types@1.0.2
-
-This package contains the following license and notice below:
-
-# micromark-util-types
-
-[![Build][build-badge]][build]
-[![Coverage][coverage-badge]][coverage]
-[![Downloads][downloads-badge]][downloads]
-[![Size][bundle-size-badge]][bundle-size]
-[![Sponsors][sponsors-badge]][opencollective]
-[![Backers][backers-badge]][opencollective]
-[![Chat][chat-badge]][chat]
-
-micromark utility with a couple of typescript types.
-
-## Contents
-
-*   [Install](#install)
-*   [Use](#use)
-*   [API](#api)
-*   [Security](#security)
-*   [Contribute](#contribute)
-*   [License](#license)
-
-## Install
-
-[npm][]:
-
-```sh
-npm install micromark-util-types
-```
-
-## Use
-
-```js
-/**
- * @typedef {import('micromark-util-types').Point} Point
- */
-```
-
-## API
-
-This module exports no identifiers.
-There is no default export.
-
-See
-[the code](https://github.com/micromark/micromark/blob/main/packages/micromark-util-types/index.js)
-for all about the exposed types.
-
-## Security
-
-See [`security.md`][securitymd] in [`micromark/.github`][health] for how to
-submit a security report.
-
-## Contribute
-
-See [`contributing.md`][contributing] in [`micromark/.github`][health] for ways
-to get started.
-See [`support.md`][support] for ways to get help.
-
-This project has a [code of conduct][coc].
-By interacting with this repository, organisation, or community you agree to
-abide by its terms.
-
-## License
-
-[MIT][license] © [Titus Wormer][author]
-
-<!-- Definitions -->
-
-[build-badge]: https://github.com/micromark/micromark/workflows/main/badge.svg
-
-[build]: https://github.com/micromark/micromark/actions
-
-[coverage-badge]: https://img.shields.io/codecov/c/github/micromark/micromark.svg
-
-[coverage]: https://codecov.io/github/micromark/micromark
-
-[downloads-badge]: https://img.shields.io/npm/dm/micromark-util-encode.svg
-
-[downloads]: https://www.npmjs.com/package/micromark-util-encode
-
-[bundle-size-badge]: https://img.shields.io/bundlephobia/minzip/micromark-util-encode.svg
-
-[bundle-size]: https://bundlephobia.com/result?p=micromark-util-encode
-
-[sponsors-badge]: https://opencollective.com/unified/sponsors/badge.svg
-
-[backers-badge]: https://opencollective.com/unified/backers/badge.svg
-
-[opencollective]: https://opencollective.com/unified
-
-[npm]: https://docs.npmjs.com/cli/install
-
-[chat-badge]: https://img.shields.io/badge/chat-discussions-success.svg
-
-[chat]: https://github.com/micromark/micromark/discussions
-
-[license]: https://github.com/micromark/micromark/blob/main/license
-
-[author]: https://wooorm.com
-
-[health]: https://github.com/micromark/.github
-
-[securitymd]: https://github.com/micromark/.github/blob/HEAD/security.md
-
-[contributing]: https://github.com/micromark/.github/blob/HEAD/contributing.md
-
-[support]: https://github.com/micromark/.github/blob/HEAD/support.md
-
-[coc]: https://github.com/micromark/.github/blob/HEAD/code-of-conduct.md
-
------------
-
-The following npm package may be included in this product:
-
- - micromark@3.1.0
-
-This package contains the following license and notice below:
-
-<h1 align="center">
-  <img src="https://raw.githubusercontent.com/micromark/micromark/2e476c9/logo.svg?sanitize=true" alt="micromark" />
-</h1>
-
-[![Build][build-badge]][build]
-[![Coverage][coverage-badge]][coverage]
-[![Downloads][downloads-badge]][downloads]
-[![Size][bundle-size-badge]][bundle-size]
-[![Sponsors][sponsors-badge]][opencollective]
-[![Backers][backers-badge]][opencollective]
-[![Chat][chat-badge]][chat]
-
-The smallest CommonMark compliant markdown parser with positional info and
-concrete tokens.
-
-## Feature highlights
-
-*   [x] **[compliant][commonmark]** (100% to CommonMark)
-*   [x] **[extensions][]** ([GFM][], [directives][], [frontmatter][], [math][],
-    [MDX.js][mdxjs])
-*   [x] **[safe][security]** (by default)
-*   [x] **[small][size]** (smallest CM parser that exists)
-*   [x] **[robust][test]** (1800+ tests, 100% coverage, fuzz testing)
-
-## When to use this
-
-*   If you *just* want to turn markdown into HTML (with maybe a few extensions)
-*   If you want to do *really complex things* with markdown
-
-See [§ Comparison][comparison] for more info
-
-## Intro
-
-micromark is a long awaited markdown parser.
-It uses a [state machine][cmsm] to parse the entirety of markdown into concrete
-tokens.
-It’s the smallest 100% [CommonMark][] compliant markdown parser in JavaScript.
-It was made to replace the internals of [`remark-parse`][remark-parse], the most
-[popular][] markdown parser.
-Its API compiles to HTML, but its parts are made to be used separately, so as to
-generate syntax trees ([`mdast-util-from-markdown`][from-markdown]) or compile
-to other output formats.
-
-*   to learn markdown, see this [cheatsheet and tutorial][cheat]
-*   for more about us, see [`unifiedjs.com`][site]
-*   for updates, see [Twitter][]
-*   for questions, see [Discussions][chat]
-*   to help, see [contribute][] or [sponsor][] below
-
-## Contents
-
-*   [Install](#install)
-*   [Use](#use)
-*   [API](#api)
-    *   [`micromark(value[, encoding][, options])`](#micromarkvalue-encoding-options)
-    *   [`stream(options?)`](#streamoptions)
-*   [Extensions](#extensions)
-    *   [List of extensions](#list-of-extensions)
-    *   [`SyntaxExtension`](#syntaxextension)
-    *   [`HtmlExtension`](#htmlextension)
-    *   [Extending markdown](#extending-markdown)
-    *   [Creating a micromark extension](#creating-a-micromark-extension)
-*   [Architecture](#architecture)
-    *   [Overview](#overview)
-    *   [Preprocess](#preprocess)
-    *   [Parse](#parse)
-    *   [Postprocess](#postprocess)
-    *   [Compile](#compile)
-*   [Examples](#examples)
-    *   [GitHub flavored markdown (GFM)](#github-flavored-markdown-gfm)
-    *   [Math](#math)
-    *   [Syntax tree](#syntax-tree)
-*   [Markdown](#markdown)
-    *   [CommonMark](#commonmark)
-    *   [Grammar](#grammar)
-*   [Project](#project)
-    *   [Comparison](#comparison)
-    *   [Test](#test)
-    *   [Size & debug](#size--debug)
-    *   [Version](#version)
-    *   [Security](#security)
-    *   [Contribute](#contribute)
-    *   [Sponsor](#sponsor)
-    *   [Origin story](#origin-story)
-    *   [License](#license)
-
-## Install
-
-This package is [ESM only][esm].
-In Node.js (version 12.20+, 14.14+, 16.0+, 18.0+), install with [npm][]:
-
-```sh
-npm install micromark
-```
-
-In Deno with [`esm.sh`][esmsh]:
-
-```js
-import {micromark} from 'https://esm.sh/micromark@3'
-```
-
-In browsers with [`esm.sh`][esmsh]:
-
-```html
-<script type="module">
-  import {micromark} from 'https://esm.sh/micromark@3?bundle'
-</script>
-```
-
-## Use
-
-Typical use (buffering):
-
-```js
-import {micromark} from 'micromark'
-
-console.log(micromark('## Hello, *world*!'))
-```
-
-Yields:
-
-```html
-<h2>Hello, <em>world</em>!</h2>
-```
-
-You can pass extensions (in this case [`micromark-extension-gfm`][gfm]):
-
-```js
-import {micromark} from 'micromark'
-import {gfm, gfmHtml} from 'micromark-extension-gfm'
-
-const value = '* [x] contact@example.com ~~strikethrough~~'
-
-const result = micromark(value, {
-  extensions: [gfm()],
-  htmlExtensions: [gfmHtml()]
-})
-
-console.log(result)
-```
-
-Yields:
-
-```html
-<ul>
-<li><input checked="" disabled="" type="checkbox"> <a href="mailto:contact@example.com">contact@example.com</a> <del>strikethrough</del></li>
-</ul>
-```
-
-Streaming interface:
-
-```js
-import fs from 'fs'
-import {stream} from 'micromark/stream'
-
-fs.createReadStream('example.md')
-  .on('error', handleError)
-  .pipe(stream())
-  .pipe(process.stdout)
-
-function handleError(error) {
-  // Handle your error here!
-  throw error
-}
-```
-
-## API
-
-`micromark` core has two entries in its export map: `micromark` and
-`micromark/stream`.
-
-`micromark` exports the following identifier: `micromark`.
-`micromark/stream` exports the following identifier: `stream`.
-There are no default exports.
-
-The export map supports the endorsed
-[`development` condition](https://nodejs.org/api/packages.html#packages_resolving_user_conditions).
-Run `node --conditions development module.js` to get instrumented dev code.
-Without this condition, production code is loaded.
-See [§ Size & debug][size-debug] for more info.
-
-### `micromark(value[, encoding][, options])`
-
-Compile markdown to HTML.
-
-##### Parameters
-
-###### `value`
-
-Markdown to parse (`string` or `Buffer`).
-
-###### `encoding`
-
-[Character encoding][encoding] to understand `value` as when it’s a
-[`Buffer`][buffer] (`string`, default: `'utf8'`).
-
-###### `options.defaultLineEnding`
-
-Value to use for line endings not in `value` (`string`, default: first line
-ending or `'\n'`).
-
-Generally, micromark copies line endings (`'\r'`, `'\n'`, `'\r\n'`) in the
-markdown document over to the compiled HTML.
-In some cases, such as `> a`, CommonMark requires that extra line endings are
-added: `<blockquote>\n<p>a</p>\n</blockquote>`.
-
-###### `options.allowDangerousHtml`
-
-Whether to allow embedded HTML (`boolean`, default: `false`).
-See [§ Security][security].
-
-###### `options.allowDangerousProtocol`
-
-Whether to allow potentially dangerous protocols in links and images (`boolean`,
-default: `false`).
-URLs relative to the current protocol are always allowed (such as, `image.jpg`).
-For links, the allowed protocols are `http`, `https`, `irc`, `ircs`, `mailto`,
-and `xmpp`.
-For images, the allowed protocols are `http` and `https`.
-See [§ Security][security].
-
-###### `options.extensions`
-
-Array of syntax extensions ([`Array<SyntaxExtension>`][syntax-extension],
-default: `[]`).
-See [§ Extensions][extensions].
-
-###### `options.htmlExtensions`
-
-Array of HTML extensions ([`Array<HtmlExtension>`][html-extension], default:
-`[]`).
-See [§ Extensions][extensions].
-
-##### Returns
-
-`string` — Compiled HTML.
-
-### `stream(options?)`
-
-Streaming interface of micromark.
-Compiles markdown to HTML.
-`options` are the same as the buffering API above.
-Note that some of the work to parse markdown can be done streaming, but in the
-end buffering is required.
-
-micromark does not handle errors for you, so you must handle errors on whatever
-streams you pipe into it.
-As markdown does not know errors, `micromark` itself does not emit errors.
-
-## Extensions
-
-micromark supports extensions.
-There are two types of extensions for micromark:
-[`SyntaxExtension`][syntax-extension],
-which change how markdown is parsed, and [`HtmlExtension`][html-extension],
-which change how it compiles.
-They can be passed in [`options.extensions`][option-extensions] or
-[`options.htmlExtensions`][option-htmlextensions], respectively.
-
-As a user of extensions, refer to each extension’s readme for more on how to use
-them.
-As a (potential) author of extensions, refer to
-[§ Extending markdown][extending-markdown] and
-[§ Creating a micromark extension][create-extension].
-
-### List of extensions
-
-*   [`micromark/micromark-extension-directive`][directives]
-    — support directives (generic extensions)
-*   [`micromark/micromark-extension-frontmatter`][frontmatter]
-    — support frontmatter (YAML, TOML, etc)
-*   [`micromark/micromark-extension-gfm`][gfm]
-    — support GFM (GitHub Flavored Markdown)
-*   [`micromark/micromark-extension-gfm-autolink-literal`](https://github.com/micromark/micromark-extension-gfm-autolink-literal)
-    — support GFM autolink literals
-*   [`micromark/micromark-extension-gfm-footnote`](https://github.com/micromark/micromark-extension-gfm-footnote)
-    — support GFM footnotes
-*   [`micromark/micromark-extension-gfm-strikethrough`](https://github.com/micromark/micromark-extension-gfm-strikethrough)
-    — support GFM strikethrough
-*   [`micromark/micromark-extension-gfm-table`](https://github.com/micromark/micromark-extension-gfm-table)
-    — support GFM tables
-*   [`micromark/micromark-extension-gfm-tagfilter`](https://github.com/micromark/micromark-extension-gfm-tagfilter)
-    — support GFM tagfilter
-*   [`micromark/micromark-extension-gfm-task-list-item`](https://github.com/micromark/micromark-extension-gfm-task-list-item)
-    — support GFM tasklists
-*   [`micromark/micromark-extension-math`][math]
-    — support math
-*   [`micromark/micromark-extension-mdx`](https://github.com/micromark/micromark-extension-mdx)
-    — support MDX
-*   [`micromark/micromark-extension-mdxjs`][mdxjs]
-    — support MDX.js
-*   [`micromark/micromark-extension-mdx-expression`](https://github.com/micromark/micromark-extension-mdx-expression)
-    — support MDX (or MDX.js) expressions
-*   [`micromark/micromark-extension-mdx-jsx`](https://github.com/micromark/micromark-extension-mdx-jsx)
-    — support MDX (or MDX.js) JSX
-*   [`micromark/micromark-extension-mdx-md`](https://github.com/micromark/micromark-extension-mdx-md)
-    — support misc MDX changes
-*   [`micromark/micromark-extension-mdxjs-esm`](https://github.com/micromark/micromark-extension-mdxjs-esm)
-    — support MDX.js import/exports
-
-#### Community extensions
-
-*   [`wataru-chocola/micromark-extension-definition-list`](https://github.com/wataru-chocola/micromark-extension-definition-list)
-    — support definition lists
-
-### `SyntaxExtension`
-
-A syntax extension is an object whose fields are typically the names of hooks,
-referring to where constructs “hook” into.
-The fields at such objects are character codes, mapping to constructs as values.
-
-The built in [constructs][] are an example.
-See it and [existing extensions][extensions] for inspiration.
-
-### `HtmlExtension`
-
-An HTML extension is an object whose fields are typically `enter` or `exit`
-(reflecting whether a token is entered or exited).
-The values at such objects are names of tokens mapping to handlers.
-
-See [existing extensions][extensions] for inspiration.
-
-### Extending markdown
-
-micromark lets you change markdown syntax, yes, but there are alternatives.
-The alternatives are often better.
-
-Over the years, many micromark and remark users have asked about their unique
-goals for markdown.
-Some exemplary goals are:
-
-1.  I want to add `rel="nofollow"` to external links
-2.  I want to add links from headings to themselves
-3.  I want line breaks in paragraphs to become hard breaks
-4.  I want to support embedded music sheets
-5.  I want authors to add arbitrary attributes
-6.  I want authors to mark certain blocks with meaning, such as tip, warning,
-    etc
-7.  I want to combine markdown with JS(X)
-8.  I want to support our legacy flavor of markdown-like syntax
-
-These can be solved in different ways and which solution is best is both
-subjective and dependant on unique needs.
-Often, there is already a solution in the form of an existing remark or rehype
-plugin.
-Respectively, their solutions are:
-
-1.  [`remark-external-links`](https://github.com/remarkjs/remark-external-links)
-2.  [`rehype-autolink-headings`](https://github.com/rehypejs/rehype-autolink-headings)
-3.  [`remark-breaks`](https://github.com/remarkjs/remark-breaks)
-4.  custom plugin similar to
-    [`rehype-katex`](https://github.com/remarkjs/remark-math/tree/main/packages/rehype-katex)
-    but integrating [`abcjs`](https://www.abcjs.net)
-5.  either [`remark-directive`](https://github.com/remarkjs/remark-directive)
-    and a custom plugin or with
-    [`rehype-attr`](https://github.com/jaywcjlove/rehype-attr)
-6.  [`remark-directive`](https://github.com/remarkjs/remark-directive)
-    combined with a custom plugin
-7.  combining the existing micromark MDX extensions however you please, such as
-    done by [`mdx-js/mdx`](https://github.com/mdx-js/mdx) or
-    [`xdm`](https://github.com/wooorm/xdm)
-8.  Writing a micromark extension
-
-Looking at these from a higher level, they can be categorized:
-
-*   **Changing the output by transforming syntax trees**
-    (1 and 2)
-
-    This category is nice as the format remains plain markdown that authors are
-    already familiar with and which will work with existing tools and platforms.
-
-    Implementations will deal with the syntax tree
-    ([`mdast`][mdast]) and the ecosystems
-    **[remark][]** and **[rehype][]**.
-    There are many existing
-    [utilities for working with that tree][utilities].
-    Many [remark plugins][] and [rehype plugins][] also exist.
-*   **Using and abusing markdown to add new meaning**
-    (3, 4, potentially 5)
-
-    This category is similar to *Changing the output by transforming syntax
-    trees*, but adds a new meaning to certain things which already have
-    semantics in markdown.
-
-    Some examples in pseudo code:
-
-    ````markdown
-    *   **A list item with the first paragraph bold**
-
-        And then more content, is turned into `<dl>` / `<dt>` / `<dd>` elements
-
-    Or, the title attributes on links or images is [overloaded](/url 'rel:nofollow')
-    with a new meaning.
-
-    ```csv
-    fenced,code,can,include,data
-    which,is,turned,into,a,graph
-    ```
-
-    ```js data can="be" passed=true
-    // after the code language name
-    ```
-
-    HTML, especially comments, could be used as **markers**<!--id="markers"-->
-    ````
-*   **Arbitrary extension mechanism**
-    (potentially 5; 6)
-
-    This category is nice when content should contain embedded “components”.
-    Often this means it’s required for authors to have some programming
-    experience.
-    There are three good ways to solve arbitrary extensions.
-
-    **HTML**: Markdown already has an arbitrary extension syntax.
-    It works in most places and authors are already familiar with the syntax,
-    but it’s reasonably hard to implement securely.
-    Certain platforms will remove HTML completely, others sanitize it to varying
-    degrees.
-    HTML also supports custom elements.
-    These could be used and enhanced by client side JavaScript or enhanced when
-    transforming the syntax tree.
-
-    **Generic directives**: although
-    [a proposal][directive-proposal]
-    and not supported on most platforms, directives do work with many tools
-    already.
-    They’re not the easiest to author compared to, say, a heading, but sometimes
-    that’s okay.
-    They do have potential: they nicely solve the need for an infinite number of
-    potential extensions to markdown in a single markdown-esque way.
-
-    **MDX** also adds support for components by swapping HTML out for JS(X).
-    JSX is an extension to JavaScript, so MDX is something along the lines of
-    literate programming.
-    This does require knowledge of React (or Vue) and JavaScript, excluding some
-    authors.
-*   **Extending markdown syntax**
-    (7 and 8)
-
-    Extend the syntax of markdown means:
-
-    *   Authors won’t be familiar with the syntax
-    *   Content won’t work in other places (such as on GitHub)
-    *   Defeating the purpose of markdown: being simple to author and looking
-        like what it means
-
-    …and it’s hard to do as it requires some in-depth knowledge of JavaScript
-    and parsing.
-    But it’s possible and in certain cases very powerful.
-
-### Creating a micromark extension
-
-This section shows how to create an extension for micromark that parses
-“variables” (a way to render some data) and one to turn a default construct off.
-
-> Stuck?
-> See [`support.md`][support].
-
-#### Prerequisites
-
-*   You should possess an intermediate to high understanding of JavaScript:
-    it’s going to get a bit complex
-*   Read the readme of [unified][] (until you hit the API section) to better
-    understand where micromark fits
-*   Read the [§ Architecture][architecture] section to understand how micromark
-    works
-*   Read the [§ Extending markdown][extending-markdown] section to understand
-    whether it’s a good idea to extend the syntax of markdown
-
-#### Extension basics
-
-micromark supports two types of extensions.
-Syntax extensions change how markdown is parsed.
-HTML extensions change how it compiles.
-
-HTML extensions are not always needed, as micromark is often used through
-[`mdast-util-from-markdown`][from-markdown] to parse to a markdown syntax tree
-So instead of an HTML extension a `from-markdown` utility is needed.
-Then, a [`mdast-util-to-markdown`][to-markdown] utility, which is responsible
-for serializing syntax trees to markdown, is also needed.
-
-When developing something for internal use only, you can pick and choose which
-parts you need.
-When open sourcing your extensions, it should probably contain four parts:
-syntax extension, HTML extension, `from-markdown` utility, and a `to-markdown`
-utility.
-
-On to our first case!
-
-#### Case: variables
-
-Let’s first outline what we want to make: render some data, similar to how
-[Liquid](https://github.com/Shopify/liquid/wiki/Liquid-for-Designers) and the
-like work, in our markdown.
-It could look like this:
-
-```markdown
-Hello, {planet}!
-```
-
-Turned into:
-
-```html
-<p>Hello, Venus!</p>
-```
-
-An opening curly brace, followed by one or more characters, and then a closing
-brace.
-We’ll then look up `planet` in some object and replace the variable with its
-corresponding value, to get something like `Venus` out.
-
-It looks simple enough, but with markdown there are often a couple more things
-to think about.
-For this case, I can see the following:
-
-*   Is there a “block” version too?
-*   Are spaces allowed?
-    Line endings?
-    Should initial and final white space be ignored?
-*   Balanced nested braces?
-    Superfluous ones such as `{{planet}}` or meaningful ones such as
-    `{a {pla} net}`?
-*   Character escapes (`{pla\}net}`) and character references
-    (`{pla&#x7d;net}`)?
-
-To keep things as simple as possible, let’s not support a block syntax, see
-spaces as special, support line endings, or support nested braces.
-But to learn interesting things, we *will* support character escapes and
-\-references.
-
-Note that this particular case is already solved quite nicely by
-[`micromark-extension-mdx-expression`][mdx-expression].
-It’s a bit more powerful and does more things, but it can be used to solve this
-case and otherwise serve as inspiration.
-
-##### Setup
-
-Create a new folder, enter it, and set up a new package:
-
-```sh
-mkdir example
-cd example
-npm init -y
-```
-
-In this example we’ll use ESM, so add `type: 'module'` to `package.json`:
-
-```diff
-@@ -2,6 +2,7 @@
-   "name": "example",
-   "version": "1.0.0",
-   "description": "",
-+  "type": "module",
-   "main": "index.js",
-   "scripts": {
-     "test": "echo \"Error: no test specified\" && exit 1"
-```
-
-Add a markdown file, `example.md`, with the following text:
-
-```markdown
-Hello, {planet}!
-
-{pla\}net} and {pla&#x7d;net}.
-```
-
-To check if our extension works, add an `example.js` module, with the following
-code:
-
-```js
-import {promises as fs} from 'node:fs'
-import {micromark} from 'micromark'
-import {variables} from './index.js'
-
-main()
-
-async function main() {
-  const buf = await fs.readFile('example.md')
-  const out = micromark(buf, {extensions: [variables]})
-  console.log(out)
-}
-```
-
-While working on the extension, run `node example` to see whether things work.
-Feel free to add more examples of the variables syntax in `example.md` if
-needed.
-
-Our extension doesn’t work yet, for one because `micromark` is not installed:
-
-```sh
-npm install micromark --save-dev
-```
-
-…and we need to write our extension.
-Let’s do that in `index.js`:
-
-```js
-export const variables = {}
-```
-
-Although our extension doesn’t do anything, running `node example` now somewhat
-works!
-
-##### Syntax extension
-
-Much in micromark is based on character codes (see [§ Preprocess][preprocess]).
-For this extension, the relevant codes are:
-
-*   `-5`
-    — M-0005 CARRIAGE RETURN (CR)
-*   `-4`
-    — M-0004 LINE FEED (LF)
-*   `-3`
-    — M-0003 CARRIAGE RETURN LINE FEED (CRLF)
-*   `null`
-    — EOF (end of the stream)
-*   `92`
-    — U+005C BACKSLASH (`\`)
-*   `123`
-    — U+007B LEFT CURLY BRACE (`{`)
-*   `125`
-    — U+007D RIGHT CURLY BRACE (`}`)
-
-Also relevant are the content types (see [§ Content types][content-types]).
-This extension is a *text* construct, as it’s parsed alongsides links and such.
-The content inside it (between the braces) is *string*, to support character
-escapes and -references.
-
-Let’s write our extension.
-Add the following code to `index.js`:
-
-```js
-const variableConstruct = {name: 'variable', tokenize: variableTokenize}
-
-export const variables = {text: {123: variableConstruct}}
-
-function variableTokenize(effects, ok, nok) {
-  return start
-
-  function start(code) {
-    console.log('start:', effects, code);
-    return nok(code)
-  }
-}
-```
-
-The above code exports an extension with the identifier `variables`.
-The extension defines a *text* construct for the character code `123`.
-The construct has a `name`, so that it can be turned off (optional, see next
-case), and it has a `tokenize` function that sets up a state machine, which
-receives `effects` and the `ok` and `nok` states.
-`ok` can be used when successful, `nok` when not, and so constructs are a bit
-similar to how promises can *resolve* or *reject*.
-`tokenize` returns the initial state, `start`, which itself receives the current
-character code, prints some debugging information, and then returns a call
-to `nok`.
-
-Ensure that things work by running `node example` and see what it prints.
-
-Now we need to define our states and figure out how variables work.
-Some people prefer sketching a diagram of the flow.
-I often prefer writing it down in pseudo-code prose.
-I’ve also found that test driven development works well, where I write unit
-tests for how it should work, then write the state machine, and finally use a
-code coverage tool to ensure I’ve thought of everything.
-
-In prose, what we have to code looks like this:
-
-*   **start**:
-    Receive `123` as `code`, enter a token for the whole (let’s call it
-    `variable`), enter a token for the marker (`variableMarker`), consume
-    `code`, exit the marker token, enter a token for the contents
-    (`variableString`), switch to *begin*
-*   **begin**:
-    If `code` is `125`, reconsume in *nok*.
-    Else, reconsume in *inside*
-*   **inside**:
-    If `code` is `-5`, `-4`, `-3`, or `null`, reconsume in `nok`.
-    Else, if `code` is `125`, exit the string token, enter a `variableMarker`,
-    consume `code`, exit the marker token, exit the variable token, and switch
-    to *ok*.
-    Else, consume, and remain in *inside*.
-
-That should be it!
-Replace `variableTokenize` with the following to include the needed states:
-
-```js
-function variableTokenize(effects, ok, nok) {
-  return start
-
-  function start(code) {
-    effects.enter('variable')
-    effects.enter('variableMarker')
-    effects.consume(code)
-    effects.exit('variableMarker')
-    effects.enter('variableString')
-    return begin
-  }
-
-  function begin(code) {
-    return code === 125 ? nok(code) : inside(code)
-  }
-
-  function inside(code) {
-    if (code === -5 || code === -4 || code === -3 || code === null) {
-      return nok(code)
-    }
-
-    if (code === 125) {
-      effects.exit('variableString')
-      effects.enter('variableMarker')
-      effects.consume(code)
-      effects.exit('variableMarker')
-      effects.exit('variable')
-      return ok
-    }
-
-    effects.consume(code)
-    return inside
-  }
-}
-```
-
-Run `node example` again and see what it prints!
-The HTML compiler ignores things it doesn’t know, so variables are now removed.
-
-We have our first syntax extension, and it sort of works, but we don’t handle
-character escapes and -references yet.
-We need to do two things to make that work:
-a) skip over `\\` and `\}` in our algorithm,
-b) tell micromark to parse them.
-
-Change the code in `index.js` to support escapes like so:
-
-```diff
-@@ -23,6 +23,11 @@ function variableTokenize(effects, ok, nok) {
-       return nok(code)
-     }
-
-+    if (code === 92) {
-+      effects.consume(code)
-+      return insideEscape
-+    }
-+
-     if (code === 125) {
-       effects.exit('variableString')
-       effects.enter('variableMarker')
-@@ -35,4 +40,13 @@ function variableTokenize(effects, ok, nok) {
-     effects.consume(code)
-     return inside
-   }
-+
-+  function insideEscape(code) {
-+    if (code === 92 || code === 125) {
-+      effects.consume(code)
-+      return inside
-+    }
-+
-+    return inside(code)
-+  }
- }
-```
-
-Finally add support for character references and character escapes between
-braces by adding a special token that defines a content type:
-
-```diff
-@@ -11,6 +11,7 @@ function variableTokenize(effects, ok, nok) {
-     effects.consume(code)
-     effects.exit('variableMarker')
-     effects.enter('variableString')
-+    effects.enter('chunkString', {contentType: 'string'})
-     return begin
-   }
-
-@@ -29,6 +30,7 @@ function variableTokenize(effects, ok, nok) {
-     }
-
-     if (code === 125) {
-+      effects.exit('chunkString')
-       effects.exit('variableString')
-       effects.enter('variableMarker')
-       effects.consume(code)
-```
-
-Tokens with a `contentType` will be replaced by *postprocess* (see
-[§ Postprocess][postprocess]) by the tokens belonging to that content type.
-
-##### HTML extension
-
-Up next is an HTML extension to replace variables with data.
-Change `example.js` to use one like so:
-
-```diff
-@@ -1,11 +1,12 @@
- import {promises as fs} from 'node:fs'
- import {micromark} from 'micromark'
--import {variables} from './index.js'
-+import {variables, variablesHtml} from './index.js'
-
- main()
-
- async function main() {
-   const buf = await fs.readFile('example.md')
--  const out = micromark(buf, {extensions: [variables]})
-+  const html = variablesHtml({planet: '1', 'pla}net': '2'})
-+  const out = micromark(buf, {extensions: [variables], htmlExtensions: [html]})
-   console.log(out)
- }
-```
-
-And add the HTML extension, `variablesHtml`, to `index.js` like so:
-
-```diff
-@@ -52,3 +52,19 @@ function variableTokenize(effects, ok, nok) {
-     return inside(code)
-   }
- }
-+
-+export function variablesHtml(data = {}) {
-+  return {
-+    enter: {variableString: enterVariableString},
-+    exit: {variableString: exitVariableString},
-+  }
-+
-+  function enterVariableString() {
-+    this.buffer()
-+  }
-+
-+  function exitVariableString() {
-+    var id = this.resume()
-+    if (id in data) {
-+      this.raw(this.encode(data[id]))
-+    }
-+  }
-+}
-```
-
-`variablesHtml` is a function that receives an object mapping “variables” to
-strings and returns an HTML extension.
-The extension hooks two functions to `variableString`, one when it starts,
-the other when it ends.
-We don’t need to do anything to handle the other tokens as they’re already
-ignored by default.
-`enterVariableString` calls `buffer`, which is a function that “stashes” what
-would otherwise be emitted.
-`exitVariableString` calls `resume`, which is the inverse of `buffer` and
-returns the stashed value.
-If the variable is defined, we ensure it’s made safe (with `this.encode`) and
-finally output that (with `this.raw`).
-
-##### Further exercises
-
-It works!
-We’re done!
-Of course, it can be better, such as with the following potential features:
-
-*   Add support for empty variables
-*   Add support for spaces between markers and string
-*   Add support for line endings in variables
-*   Add support for nested braces
-*   Add support for blocks
-*   Add warnings on undefined variables
-*   Use `micromark-build`, and use `uvu/assert`, `debug`, and
-    `micromark-util-symbol` (see [§ Size & debug][size-debug])
-*   Add [`mdast-util-from-markdown`][from-markdown] and
-    [`mdast-util-to-markdown`][to-markdown] utilities to parse and serialize the
-    AST
-
-#### Case: turn off constructs
-
-Sometimes it’s needed to turn a default construct off.
-That’s possible through a syntax extension.
-Note that not everything can be turned off (such as paragraphs) and even if it’s
-possible to turn something off, it could break micromark (such as character
-escapes).
-
-To disable constructs, refer to them by name in an array at the `disable.null`
-field of an extension:
-
-```js
-import {micromark} from 'micromark'
-
-const extension = {disable: {null: ['codeIndented']}}
-
-console.log(micromark('\ta', {extensions: [extension]}))
-```
-
-Yields:
-
-```html
-<p>a</p>
-```
-
-## Architecture
-
-micromark is maintained as a monorepo.
-Many of its internals, which are used in `micromark` (core) but also useful for
-developers of extensions or integrations, are available as separate modules.
-Each module maintained here is available in [`packages/`][packages].
-
-### Overview
-
-The naming scheme in [`packages/`][packages] is as follows:
-
-*   `micromark-build`
-    — Small CLI to build dev code into production code
-*   `micromark-core-commonmark`
-    — CommonMark constructs used in micromark
-*   `micromark-factory-*`
-    — Reusable subroutines used to parse parts of constructs
-*   `micromark-util-*`
-    — Reusable helpers often needed when parsing markdown
-*   `micromark`
-    — Core module
-
-micromark has two interfaces: buffering (maintained in
-[`micromark/dev/index.js`](https://github.com/micromark/micromark/blob/main/packages/micromark/dev/index.js))
-and streaming (maintained in
-[`micromark/dev/stream.js`](https://github.com/micromark/micromark/blob/main/packages/micromark/dev/stream.js)).
-The first takes all input at once whereas the last uses a Node.js stream to take
-input separately.
-They thinly wrap how data flows through micromark:
-
-```txt
-                                            micromark
-+-----------------------------------------------------------------------------------------------+
-|            +------------+         +-------+         +-------------+         +---------+       |
-| -markdown->+ preprocess +-chunks->+ parse +-events->+ postprocess +-events->+ compile +-html- |
-|            +------------+         +-------+         +-------------+         +---------+       |
-+-----------------------------------------------------------------------------------------------+
-```
-
-### Preprocess
-
-The **preprocessor**
-([`micromark/dev/lib/preprocess.js`](https://github.com/micromark/micromark/blob/main/packages/micromark/dev/lib/preprocess.js))
-takes markdown and turns it into chunks.
-
-A **chunk** is either a character code or a slice of a buffer in the form of a
-string.
-Chunks are used because strings are more efficient storage than character codes,
-but limited in what they can represent.
-For example, the input `ab\ncd` is represented as `['ab', -4, 'cd']` in chunks.
-
-A character **code** is often the same as what `String#charCodeAt()` yields but
-micromark adds meaning to certain other values.
-
-In micromark, the actual character U+0009 CHARACTER TABULATION (HT) is replaced
-by one M-0002 HORIZONTAL TAB (HT) and between 0 and 3 M-0001 VIRTUAL SPACE (VS)
-characters, depending on the column at which the tab occurred.
-For example, the input `\ta` is represented as `[-2, -1, -1, -1, 97]` and `a\tb`
-as `[97, -2, -1, -1, 98]` in character codes.
-
-The characters U+000A LINE FEED (LF) and U+000D CARRIAGE RETURN (CR) are
-replaced by virtual characters depending on whether they occur together: M-0003
-CARRIAGE RETURN LINE FEED (CRLF), M-0004 LINE FEED (LF), and M-0005 CARRIAGE
-RETURN (CR).
-For example, the input `a\r\nb\nc\rd` is represented as
-`[97, -5, 98, -4, 99, -3, 100]` in character codes.
-
-The `0` (U+0000 NUL) character code is replaced by U+FFFD REPLACEMENT CHARACTER
-(`�`).
-
-The `null` code represents the end of the input stream (called *eof* for end of
-file).
-
-### Parse
-
-The **parser**
-([`micromark/dev/lib/parse.js`](https://github.com/micromark/micromark/blob/main/packages/micromark/dev/lib/parse.js))
-takes chunks and turns them into events.
-
-An **event** is the start or end of a token amongst other events.
-Tokens can “contain” other tokens, even though they are stored in a flat list,
-by entering before and exiting after them.
-
-A **token** is a span of one or more codes.
-Tokens are most of what micromark produces: the built in HTML compiler or other
-tools can turn them into different things.
-Tokens are essentially names attached to a slice, such as `lineEndingBlank` for
-certain line endings, or `codeFenced` for a whole fenced code.
-
-Sometimes, more info is attached to tokens, such as `_open` and `_close` by
-`attention` (strong, emphasis) to signal whether the sequence can open or close
-an attention run.
-These fields have to do with how the parser works, which is complex and not
-always pretty.
-
-Certain fields (`previous`, `next`, and `contentType`) are used in many cases:
-linked tokens for subcontent.
-Linked tokens are used because outer constructs are parsed first.
-Take for example:
-
-```markdown
-- *a
-  b*.
-```
-
-1.  The list marker and the space after it is parsed first
-2.  The rest of the line is a `chunkFlow` token
-3.  The two spaces on the second line are a `linePrefix` of the list
-4.  The rest of the line is another `chunkFlow` token
-
-The two `chunkFlow` tokens are linked together and the chunks they span are
-passed through the flow tokenizer.
-There the chunks are seen as `chunkContent` and passed through the content
-tokenizer.
-There the chunks are seen as a paragraph and seen as `chunkText` and passed
-through the text tokenizer.
-Finally, the attention (emphasis) and data (“raw” characters) is parsed there,
-and we’re done!
-
-#### Content types
-
-The parser starts out with a document tokenizer.
-*Document* is the top-most content type, which includes containers such as block
-quotes and lists.
-Containers in markdown come from the margin and include more constructs
-on the lines that define them.
-
-*Flow* represents the sections (block constructs such as ATX and setext
-headings, HTML, indented and fenced code, thematic breaks), which like
-*document* are also parsed per line.
-An example is HTML, which has a certain starting condition (such as `<script>`
-on its own line), then continues for a while, until an end condition is found
-(such as `</style>`).
-If that line with an end condition is never found, that flow goes until the end.
-
-*Content* is zero or more definitions, and then zero or one paragraph.
-It’s a weird one, and needed to make certain edge cases around definitions spec
-compliant.
-Definitions are unlike other things in markdown, in that they behave like *text*
-in that they can contain arbitrary line endings, but *have* to end at a line
-ending.
-If they end in something else, the whole definition instead is seen as a
-paragraph.
-
-The content in markdown first needs to be parsed up to this level to figure out
-which things are defined, for the whole document, before continuing on with
-*text*, as whether a link or image reference forms or not depends on whether
-it’s defined.
-This unfortunately prevents a true streaming markdown parser.
-
-*Text* contains phrasing content (rich inline text: autolinks, character escapes
-and -references, code, hard breaks, HTML, images, links, emphasis, strong).
-
-*String* is a limited *text*-like content type which only allows character
-references and character escapes.
-It exists in things such as identifiers (media references, definitions),
-titles, or URLs and such.
-
-#### Constructs
-
-Constructs are the things that make up markdown.
-Some examples are lists, thematic breaks, or character references.
-
-Note that, as a general rule of thumb, markdown is *really weird*.
-It’s essentially made up of edge cases rather than logical rules.
-When browsing the built in constructs, or venturing to build your own, you’ll
-find confusing new things and run into complex custom hooks.
-
-One more reasonable construct is the thematic break
-([see code](https://github.com/micromark/micromark/blob/main/packages/micromark-core-commonmark/dev/lib/thematic-break.js)).
-It’s an object that defines a `name` and a `tokenize` function.
-Most of what constructs do is defined in their required `tokenize` function,
-which sets up a state machine to handle character codes streaming in.
-
-### Postprocess
-
-The **postprocessor**
-([`micromark/dev/lib/postprocess.js`](https://github.com/micromark/micromark/blob/main/packages/micromark/dev/lib/postprocess.js))
-is a small step that takes events, ensures all their
-nested content is parsed, and returns the modified events.
-
-### Compile
-
-The **compiler**
-([`micromark/dev/lib/compile.js`](https://github.com/micromark/micromark/blob/main/packages/micromark/dev/lib/compile.js))
-takes events and turns them into HTML.
-While micromark was created mostly to advance markdown parsing irrespective of
-compiling to HTML, the common case of doing so is built in.
-A built in HTML compiler is useful because it allows us to check for compliancy
-to CommonMark, the de facto norm of markdown, specified in roughly 650
-input/output cases.
-The parsing parts can still be used separately to build ASTs, CSTs, or many
-other output formats.
-
-The compiler has an interface that accepts lists of events instead of the whole
-at once, but because markdown can’t truly stream, events are buffered before
-compiling and outputting the final result.
-
-## Examples
-
-### GitHub flavored markdown (GFM)
-
-To support GFM (autolink literals, strikethrough, tables, and tasklists) use
-[`micromark-extension-gfm`][gfm].
-Say we have a file like this:
-
-```markdown
-# GFM
-
-## Autolink literals
-
-www.example.com, https://example.com, and contact@example.com.
-
-## Footnote
-
-A note[^1]
-
-[^1]: Big note.
-
-## Strikethrough
-
-~one~ or ~~two~~ tildes.
-
-## Table
-
-| a | b  |  c |  d  |
-| - | :- | -: | :-: |
-
-## Tag filter
-
-<plaintext>
-
-## Tasklist
-
-* [ ] to do
-* [x] done
-```
-
-Then do something like this:
-
-```js
-import fs from 'node:fs'
-import {micromark} from 'micromark'
-import {gfm, gfmHtml} from 'micromark-extension-gfm'
-
-const doc = fs.readFileSync('example.md')
-
-console.log(micromark(doc, {extensions: [gfm()], htmlExtensions: [gfmHtml()]}))
-```
-
-<details>
-<summary>Show equivalent HTML</summary>
-
-```html
-<h1>GFM</h1>
-<h2>Autolink literals</h2>
-<p><a href="http://www.example.com">www.example.com</a>, <a href="https://example.com">https://example.com</a>, and <a href="mailto:contact@example.com">contact@example.com</a>.</p>
-<h2>Footnote</h2>
-<p>A note<sup><a href="#user-content-fn-1" id="user-content-fnref-1" data-footnote-ref="" aria-describedby="footnote-label">1</a></sup></p>
-<h2>Strikethrough</h2>
-<p><del>one</del> or <del>two</del> tildes.</p>
-<h2>Table</h2>
-<table>
-<thead>
-<tr>
-<th>a</th>
-<th align="left">b</th>
-<th align="right">c</th>
-<th align="center">d</th>
-</tr>
-</thead>
-</table>
-<h2>Tag filter</h2>
-&lt;plaintext&gt;
-<h2>Tasklist</h2>
-<ul>
-<li><input disabled="" type="checkbox"> to do</li>
-<li><input checked="" disabled="" type="checkbox"> done</li>
-</ul>
-<section data-footnotes="" class="footnotes"><h2 id="footnote-label" class="sr-only">Footnotes</h2>
-<ol>
-<li id="user-content-fn-1">
-<p>Big note. <a href="#user-content-fnref-1" data-footnote-backref="" class="data-footnote-backref" aria-label="Back to content">↩</a></p>
-</li>
-</ol>
-</section>
-```
-
-</details>
-
-### Math
-
-To support math use [`micromark-extension-math`][math].
-Say we have a file like this:
-
-```markdown
-Lift($L$) can be determined by Lift Coefficient ($C_L$) like the following equation.
-
-$$
-L = \frac{1}{2} \rho v^2 S C_L
-$$
-```
-
-Then do something like this:
-
-```js
-import fs from 'node:fs'
-import {micromark} from 'micromark'
-import {math, mathHtml} from 'micromark-extension-math'
-
-const doc = fs.readFileSync('example.md')
-
-console.log(micromark(doc, {extensions: [math], htmlExtensions: [mathHtml()]}))
-```
-
-<details>
-<summary>Show equivalent HTML</summary>
-
-```html
-<p>Lift(<span class="math math-inline"><span class="katex">…</span></span>) can be determined by Lift Coefficient (<span class="math math-inline"><span class="katex">…</span></span>) like the following equation.</p>
-<div class="math math-display"><span class="katex-display"><span class="katex">…</span></span></div>
-```
-
-</details>
-
-### Syntax tree
-
-A higher level project, [`mdast-util-from-markdown`][from-markdown], can give
-you an AST.
-
-```js
-import fromMarkdown from 'mdast-util-from-markdown' // This wraps micromark.
-
-const result = fromMarkdown('## Hello, *world*!')
-
-console.log(result.children[0])
-```
-
-Yields:
-
-```js
-{
-  type: 'heading',
-  depth: 2,
-  children: [
-    {type: 'text', value: 'Hello, ', position: [Object]},
-    {type: 'emphasis', children: [Array], position: [Object]},
-    {type: 'text', value: '!', position: [Object]}
-  ],
-  position: {
-    start: {line: 1, column: 1, offset: 0},
-    end: {line: 1, column: 19, offset: 18}
-  }
-}
-```
-
-Another level up is [**remark**][remark], which provides a nice interface and
-hundreds of plugins.
-
-## Markdown
-
-### CommonMark
-
-The first definition of “Markdown” gave several examples of how it worked,
-showing input Markdown and output HTML, and came with a reference implementation
-(`Markdown.pl`).
-When new implementations followed, they mostly followed the first definition,
-but deviated from the first implementation, and added extensions, thus making
-the format a family of formats.
-
-Some years later, an attempt was made to standardize the differences between
-implementations, by specifying how several edge cases should be handled, through
-more input and output examples.
-This is known as [CommonMark][commonmark-spec], and many implementations now
-work towards some degree of CommonMark compliancy.
-Still, CommonMark describes what the output in HTML should be given some
-input, which leaves many edge cases up for debate, and does not answer what
-should happen for other output formats.
-
-micromark passes all tests from CommonMark and has many more tests to match the
-CommonMark reference parsers.
-Finally, it comes with [CMSM][], which describes how to parse markup, instead
-of documenting input and output examples.
-
-### Grammar
-
-The syntax of markdown can be described in Backus–Naur form (BNF) as:
-
-```bnf
-markdown = .*
-```
-
-No, that’s [not a typo](http://trevorjim.com/a-specification-for-markdown/):
-markdown has no syntax errors; anything thrown at it renders *something*.
-
-## Project
-
-### Comparison
-
-There are many other markdown parsers out there and maybe they’re better suited
-to your use case!
-Here is a short comparison of a couple in JavaScript.
-Note that this list is made by the folks who make `micromark` and `remark`, so
-there is some bias.
-
-**Note**: these are, in fact, not really comparable: micromark (and remark)
-focus on completely different things than other markdown parsers do.
-Sure, you can generate HTML from markdown with them, but micromark (and remark)
-are created for (abstract or concrete) syntax trees—to inspect, transform, and
-generate content, so that you can make things like [MDX][], [Prettier][], or
-[Gatsby][].
-
-###### micromark
-
-micromark can be used in two different ways.
-It can either be used, optionally with existing extensions, to get HTML easily.
-Or, it can give tremendous power, such as access to all tokens with positional
-info, at the cost of being hard to get into.
-It’s super small, pretty fast, and has 100% CommonMark compliance.
-It has syntax extensions, such as supporting 100% GFM compliance (with
-`micromark-extension-gfm`), but they’re rather complex to write.
-It’s the newest parser on the block, which means it’s fresh and well suited for
-contemporary markdown needs, but it’s also battle-tested, and already the 3rd
-most popular markdown parser in JavaScript.
-
-If you’re looking for fine grained control, use micromark.
-If you just want HTML from markdown, use micromark.
-
-###### remark
-
-[remark][] is the most popular markdown parser.
-It’s built on top of `micromark` and boasts syntax trees.
-For an analogy, it’s like if Babel, ESLint, and more, were one project.
-It supports the syntax extensions that micromark has (so it’s 100% CM compliant
-and can be 100% GFM compliant), but most of the work is done in plugins that
-transform or inspect the tree, and there’s *tons* of them.
-Transforming the tree is relatively easy: it’s a JSON object that can be
-manipulated directly.
-remark is stable, widely used, and extremely powerful for handling complex data.
-
-You probably should use [remark][].
-
-###### marked
-
-[marked][] is the oldest markdown parser on the block.
-It’s been around for ages, is battle tested, small, popular, and has a bunch of
-extensions, but doesn’t match CommonMark or GFM, and is unsafe by default.
-
-If you have markdown you trust and want to turn it into HTML without a fuss, and
-don’t care about perfect compatibility with CommonMark or GFM, but do appreciate
-a small bundle size and stability, use [marked][].
-
-###### markdown-it
-
-[markdown-it][] is a good, stable, and essentially CommonMark compliant markdown
-parser, with (optional) support for some GFM features as well.
-It’s used a lot as a direct dependency in packages, but is rather big.
-It shines at syntax extensions, where you want to support not just markdown, but
-*your* (company’s) version of markdown.
-
-If you need a couple of custom syntax extensions to your otherwise
-CommonMark-compliant markdown, and want to get HTML out, use [markdown-it][].
-
-###### Others
-
-There are lots of other markdown parsers!
-Some say they’re small, or fast, or that they’re CommonMark compliant—but
-that’s not always true.
-This list is not supposed to be exhaustive (but it’s the most relevant ones).
-This list of markdown parsers is a snapshot in time of why (not) to use
-(alternatives to) `micromark`: they’re all good choices, depending on what your
-goals are.
-
-### Test
-
-micromark is tested with the \~650 CommonMark tests and more than 1.2k extra
-tests confirmed with CM reference parsers.
-These tests reach all branches in the code, which means that this project has
-100% code coverage.
-Finally, we use fuzz testing to ensure micromark is stable, reliable, and
-secure.
-
-To build, format, and test the codebase, use `$ npm test` after clone and
-install.
-The `$ npm run test-api` and `$ npm run test-coverage` scripts check either the
-unit tests, or both them and their coverage, respectively.
-
-The `$ npm run test-fuzz` script does fuzz testing for 15 minutes.
-The timeout is provided by GNU coreutils **timeout(1)**, which might not be
-available on your system.
-Either install `timeout` or remove that part temporarily from the script and
-manually exit the program after a while.
-
-### Size & debug
-
-micromark is really small.
-A ton of time went into making sure it minifies well, by the way code is written
-but also through custom build scripts to pre-evaluate certain expressions.
-Furthermore, care went into making it compress well with gzip and brotli.
-
-Normally, you’ll use the pre-evaluated version of micromark.
-While developing, debugging, or testing your code, you *should* switch to use
-code instrumented with assertions and debug messages:
-
-```sh
-node --conditions development module.js
-```
-
-To see debug messages, use a `DEBUG` env variable set to `micromark`:
-
-```sh
-DEBUG="*" node --conditions development module.js
-```
-
-### Version
-
-micromark adheres to [semver](https://semver.org) since 3.0.0.
-
-### Security
-
-The typical security aspect discussed for markdown is [cross-site scripting
-(XSS)][xss] attacks.
-Markdown itself is safe if it does not include embedded HTML or dangerous
-protocols in links/images (such as `javascript:` or `data:`).
-micromark makes any markdown safe by default, even if HTML is embedded or
-dangerous protocols are used, as it encodes or drops them.
-Turning on the `allowDangerousHtml` or `allowDangerousProtocol` options for
-user-provided markdown opens you up to XSS attacks.
-
-Another security aspect is DDoS attacks.
-For example, an attacker could throw a 100mb file at micromark, in which case
-the JavaScript engine will run out of memory and crash.
-It is also possible to crash micromark with smaller payloads, notably when
-thousands of links, images, emphasis, or strong are opened but not closed.
-It is wise to cap the accepted size of input (500kb can hold a big book) and to
-process content in a different thread or worker so that it can be stopped when
-needed.
-
-Using extensions might also be unsafe, refer to their documentation for more
-information.
-
-For more information on markdown sanitation, see
-[`improper-markup-sanitization.md`][improper] by [**@chalker**][chalker].
-
-See [`security.md`][securitymd] in [`micromark/.github`][health] for how to
-submit a security report.
-
-### Contribute
-
-See [`contributing.md`][contributing] in [`micromark/.github`][health] for ways
-to get started.
-See [`support.md`][support] for ways to get help.
-
-This project has a [code of conduct][coc].
-By interacting with this repository, organisation, or community you agree to
-abide by its terms.
-
-### Sponsor
-
-Support this effort and give back by sponsoring on [OpenCollective][]!
-
-<table>
-<tr valign="middle">
-<td width="100%" align="center" colspan="10">
-  <br>
-  <a href="https://www.salesforce.com">Salesforce</a> 🏅<br><br>
-  <a href="https://www.salesforce.com"><img src="https://images.opencollective.com/salesforce/ca8f997/logo/512.png" width="256"></a>
-</td>
-</tr>
-<tr valign="middle">
-<td width="20%" align="center" rowspan="2" colspan="2">
-  <a href="https://vercel.com">Vercel</a><br><br>
-  <a href="https://vercel.com"><img src="https://avatars1.githubusercontent.com/u/14985020?s=256&v=4" width="128"></a>
-</td>
-<td width="20%" align="center" rowspan="2" colspan="2">
-  <a href="https://motif.land">Motif</a><br><br>
-  <a href="https://motif.land"><img src="https://avatars1.githubusercontent.com/u/74457950?s=256&v=4" width="128"></a>
-</td>
-<td width="20%" align="center" rowspan="2" colspan="2">
-  <a href="https://www.hashicorp.com">HashiCorp</a><br><br>
-  <a href="https://www.hashicorp.com"><img src="https://avatars1.githubusercontent.com/u/761456?s=256&v=4" width="128"></a>
-</td>
-<td width="20%" align="center" rowspan="2" colspan="2">
-  <a href="https://www.gitbook.com">GitBook</a><br><br>
-  <a href="https://www.gitbook.com"><img src="https://avatars1.githubusercontent.com/u/7111340?s=256&v=4" width="128"></a>
-</td>
-<td width="20%" align="center" rowspan="2" colspan="2">
-  <a href="https://www.gatsbyjs.org">Gatsby</a><br><br>
-  <a href="https://www.gatsbyjs.org"><img src="https://avatars1.githubusercontent.com/u/12551863?s=256&v=4" width="128"></a>
-</td>
-</tr>
-<tr valign="middle">
-</tr>
-<tr valign="middle">
-<td width="20%" align="center" rowspan="2" colspan="2">
-  <a href="https://www.netlify.com">Netlify</a><br><br>
-  <!--OC has a sharper image-->
-  <a href="https://www.netlify.com"><img src="https://images.opencollective.com/netlify/4087de2/logo/256.png" width="128"></a>
-</td>
-<td width="10%" align="center">
-  <a href="https://www.coinbase.com">Coinbase</a><br><br>
-  <a href="https://www.coinbase.com"><img src="https://avatars1.githubusercontent.com/u/1885080?s=256&v=4" width="64"></a>
-</td>
-<td width="10%" align="center">
-  <a href="https://themeisle.com">ThemeIsle</a><br><br>
-  <a href="https://themeisle.com"><img src="https://avatars1.githubusercontent.com/u/58979018?s=128&v=4" width="64"></a>
-</td>
-<td width="10%" align="center">
-  <a href="https://expo.io">Expo</a><br><br>
-  <a href="https://expo.io"><img src="https://avatars1.githubusercontent.com/u/12504344?s=128&v=4" width="64"></a>
-</td>
-<td width="10%" align="center">
-  <a href="https://boostnote.io">Boost Note</a><br><br>
-  <a href="https://boostnote.io"><img src="https://images.opencollective.com/boosthub/6318083/logo/128.png" width="64"></a>
-</td>
-<td width="10%" align="center">
-  <a href="https://www.holloway.com">Holloway</a><br><br>
-  <a href="https://www.holloway.com"><img src="https://avatars1.githubusercontent.com/u/35904294?s=128&v=4" width="64"></a>
-</td>
-<td width="10%"></td>
-<td width="10%"></td>
-<td width="10%"></td>
-</tr>
-<tr valign="middle">
-<td width="100%" align="center" colspan="8">
-  <br>
-  <a href="https://opencollective.com/unified"><strong>You?</strong></a>
-  <br><br>
-</td>
-</tr>
-</table>
-
-### Origin story
-
-Over the summer of 2018, micromark was planned, and the idea shared in August
-with a couple of friends and potential sponsors.
-The problem I (**[@wooorm][]**) had was that issues were piling up in remark and
-other repos, but my day job (teaching) was fun, fulfilling, and deserved time
-too.
-It was getting hard to combine the two.
-The thought was to feed two birds with one scone: fix the issues in remark with
-a new markdown parser (codename marydown) while being financially supported by
-sponsors building fancy stuff on top, such as Gatsby, Contentful, and Vercel
-(ZEIT at the time).
-**[@johno][]** was making MDX on top of remark at the time (important historical
-note: several other folks were working on JSX + markdown too).
-We bundled our strengths: MDX was getting some traction and we thought together
-we could perhaps make something sustainable.
-
-In November 2018, we launched with the idea for micromark to solve all existing
-bugs, sustaining the existing hundreds of projects, and furthering the exciting
-high-level project MDX.
-We pushed a single name: unified (which back then was a small but essential
-part of the chain).
-Gatsby and Vercel were immediate sponsors.
-We didn’t know whether it would work, and it worked.
-But now you have a new problem: you are getting some financial support (much
-more than other open source projects) but it’s not enough money for rent, and
-too much money to print stickers with.
-You still have your job and issues are still piling up.
-
-At the start of summer 2019, after a couple months of saving up donations, I
-quit my job and worked on unified through fall.
-That got the number of open issues down significantly and set up a strong
-governance and maintenance system for the collective.
-But when the time came to work on micromark, the money was gone again, so I
-contracted through winter 2019, and in spring 2020 I could do about half open
-source, half contracting.
-One of the contracting gigs was to write a new MDX parser, for which I also
-documented how to do that with a state machine [in prose][mdx-cmsm].
-That gave me the insight into how the same could be done for markdown: I drafted
-[CMSM][], which was some of the core ideas for micromark, but in prose.
-
-In May 2020, Salesforce reached out: they saw the bugs in remark, how micromark
-could help, and the initial work on CMSM.
-And they had thousands of Markdown files.
-In a for open source uncharacteristic move, they decided to fund my work on
-micromark.
-A large part of what maintaining open source means, is putting out fires,
-triaging issues, and making sure users and sponsors are happy, so it was
-amazing to get several months to just focus and make something new.
-I remember feeling that this project would probably be the hardest thing I’d
-work on: yeah, parsers are pretty difficult, but markdown is on another level.
-Markdown is such a giant stack of edge cases on edge cases on even more
-weirdness, what a mess.
-On August 20, 2020, I released [2.0.0][200], the first working version of
-micromark.
-And it’s hard to describe how that moment felt.
-It was great.
-
-### License
-
-[MIT][license] © [Titus Wormer][author]
-
-<!-- Definitions -->
-
-[build-badge]: https://github.com/micromark/micromark/workflows/main/badge.svg
-
-[build]: https://github.com/micromark/micromark/actions
-
-[coverage-badge]: https://img.shields.io/codecov/c/github/micromark/micromark.svg
-
-[coverage]: https://codecov.io/github/micromark/micromark
-
-[downloads-badge]: https://img.shields.io/npm/dm/micromark.svg
-
-[downloads]: https://www.npmjs.com/package/micromark
-
-[bundle-size-badge]: https://img.shields.io/bundlephobia/minzip/micromark.svg
-
-[bundle-size]: https://bundlephobia.com/result?p=micromark
-
-[sponsors-badge]: https://opencollective.com/unified/sponsors/badge.svg
-
-[backers-badge]: https://opencollective.com/unified/backers/badge.svg
-
-[opencollective]: https://opencollective.com/unified
-
-[npm]: https://docs.npmjs.com/cli/install
-
-[esm]: https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c
-
-[esmsh]: https://esm.sh
-
-[chat-badge]: https://img.shields.io/badge/chat-discussions-success.svg
-
-[chat]: https://github.com/micromark/micromark/discussions
-
-[license]: https://github.com/micromark/micromark/blob/main/license
-
-[author]: https://wooorm.com
-
-[health]: https://github.com/micromark/.github
-
-[xss]: https://en.wikipedia.org/wiki/Cross-site_scripting
-
-[securitymd]: https://github.com/micromark/.github/blob/HEAD/security.md
-
-[contributing]: https://github.com/micromark/.github/blob/HEAD/contributing.md
-
-[support]: https://github.com/micromark/.github/blob/HEAD/support.md
-
-[coc]: https://github.com/micromark/.github/blob/HEAD/code-of-conduct.md
-
-[cheat]: https://commonmark.org/help/
-
-[twitter]: https://twitter.com/unifiedjs
-
-[remark]: https://github.com/remarkjs/remark
-
-[rehype]: https://github.com/rehypejs/rehype
-
-[site]: https://unifiedjs.com
-
-[contribute]: #contribute
-
-[encoding]: https://nodejs.org/api/buffer.html#buffer_buffers_and_character_encodings
-
-[buffer]: https://nodejs.org/api/buffer.html
-
-[commonmark-spec]: https://commonmark.org
-
-[popular]: https://www.npmtrends.com/remark-parse-vs-marked-vs-markdown-it
-
-[remark-parse]: https://unifiedjs.com/explore/package/remark-parse/
-
-[improper]: https://github.com/ChALkeR/notes/blob/master/Improper-markup-sanitization.md
-
-[chalker]: https://github.com/ChALkeR
-
-[cmsm]: https://github.com/micromark/common-markup-state-machine
-
-[mdx-cmsm]: https://github.com/micromark/mdx-state-machine
-
-[from-markdown]: https://github.com/syntax-tree/mdast-util-from-markdown
-
-[to-markdown]: https://github.com/syntax-tree/mdast-util-to-markdown
-
-[directives]: https://github.com/micromark/micromark-extension-directive
-
-[frontmatter]: https://github.com/micromark/micromark-extension-frontmatter
-
-[gfm]: https://github.com/micromark/micromark-extension-gfm
-
-[math]: https://github.com/micromark/micromark-extension-math
-
-[mdxjs]: https://github.com/micromark/micromark-extension-mdxjs
-
-[constructs]: /packages/micromark/dev/lib/constructs.js
-
-[comparison]: #comparison
-
-[extensions]: #list-of-extensions
-
-[syntax-extension]: #syntaxextension
-
-[html-extension]: #htmlextension
-
-[option-extensions]: #optionsextensions
-
-[option-htmlextensions]: #optionshtmlextensions
-
-[mdast]: https://github.com/syntax-tree/mdast
-
-[utilities]: https://github.com/syntax-tree/mdast#list-of-utilities
-
-[unified]: https://github.com/unifiedjs/unified
-
-[remark plugins]: https://github.com/remarkjs/remark/blob/main/doc/plugins.md#list-of-plugins
-
-[rehype plugins]: https://github.com/rehypejs/rehype/blob/main/doc/plugins.md#list-of-plugins
-
-[directive-proposal]: https://talk.commonmark.org/t/generic-directives-plugins-syntax/444
-
-[architecture]: #architecture
-
-[extending-markdown]: #extending-markdown
-
-[create-extension]: #creating-a-micromark-extension
-
-[mdx-expression]: https://github.com/micromark/micromark-extension-mdx-expression
-
-[preprocess]: #preprocess
-
-[content-types]: https://github.com/micromark/micromark#content-types
-
-[postprocess]: https://github.com/micromark/micromark#postprocess
-
-[size-debug]: https://github.com/micromark/micromark#size--debug
-
-[packages]: https://github.com/micromark/micromark/tree/main/packages
-
-[marked]: https://github.com/markedjs/marked
-
-[markdown-it]: https://github.com/markdown-it/markdown-it
-
-[mdx]: https://github.com/mdx-js/mdx
-
-[prettier]: https://github.com/prettier/prettier
-
-[gatsby]: https://github.com/gatsbyjs/gatsby
-
-[commonmark]: #commonmark
-
-[size]: #size--debug
-
-[test]: #test
-
-[security]: #security
-
-[sponsor]: #sponsor
-
-[@wooorm]: https://github.com/wooorm
-
-[@johno]: https://github.com/johno
-
-[200]: https://github.com/micromark/micromark/releases/tag/2.0.0
-
------------
-
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - minimist@1.2.7
 
@@ -6414,7 +1409,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - ms@2.1.2
 
@@ -6444,7 +1439,7 @@ SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - murmurhash-js@1.0.0
 
@@ -6493,7 +1488,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - object-assign@4.1.1
 
@@ -6523,7 +1518,7 @@ THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - parse5@6.0.1
 
@@ -6551,7 +1546,7 @@ THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - pbf@3.2.1
 
@@ -6587,7 +1582,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - potpack@2.0.0
 
@@ -6611,7 +1606,7 @@ THIS SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - prismjs@1.29.0
 
@@ -6641,7 +1636,7 @@ THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - prop-types@15.8.1
 
@@ -6671,7 +1666,7 @@ SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - protocol-buffers-schema@3.6.0
 
@@ -6701,11 +1696,11 @@ THE SOFTWARE.
 
 -----------
 
-The following npm packages may be included in this product:
+The following NPM packages may be included in this product:
 
  - react-dom@17.0.2
  - react-is@16.13.1
- - react-is@18.2.0
+ - react-is@17.0.2
  - react@17.0.2
  - scheduler@0.20.2
 
@@ -6735,7 +1730,7 @@ SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - react-error-boundary@3.1.4
 
@@ -6764,9 +1759,9 @@ SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
- - react-markdown@8.0.5
+ - react-markdown@6.0.3
 
 This package contains the following license and notice below:
 
@@ -6794,7 +1789,7 @@ SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - regenerator-runtime@0.13.11
 
@@ -6824,16 +1819,221 @@ SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
- - remark-parse@10.0.1
+ - remark-parse@9.0.0
 
 This package contains the following license and notice below:
 
-(The MIT License)
+# remark-parse
 
-Copyright (c) 2014-2020 Titus Wormer <tituswormer@gmail.com>
-Copyright (c) 2011-2014, Christopher Jeffrey (https://github.com/chjj/)
+[![Build][build-badge]][build]
+[![Coverage][coverage-badge]][coverage]
+[![Downloads][downloads-badge]][downloads]
+[![Size][size-badge]][size]
+[![Sponsors][sponsors-badge]][collective]
+[![Backers][backers-badge]][collective]
+[![Chat][chat-badge]][chat]
+
+[Parser][] for [**unified**][unified].
+Parses Markdown to [**mdast**][mdast] syntax trees.
+Built on [`micromark`][micromark] and
+[`mdast-util-from-markdown`][from-markdown].
+Used in the [**remark** processor][remark] but can be used on its own as well.
+Can be [extended][extend] to change how Markdown is parsed.
+
+## Install
+
+[npm][]:
+
+```sh
+npm install remark-parse
+```
+
+## Use
+
+```js
+var unified = require('unified')
+var createStream = require('unified-stream')
+var markdown = require('remark-parse')
+var remark2rehype = require('remark-rehype')
+var html = require('rehype-stringify')
+
+var processor = unified().use(markdown).use(remark2rehype).use(html)
+
+process.stdin.pipe(createStream(processor)).pipe(process.stdout)
+```
+
+[See **unified** for more examples »][unified]
+
+## API
+
+[See **unified** for API docs »][unified]
+
+### `processor().use(parse)`
+
+Configure the `processor` to read Markdown as input and process
+[**mdast**][mdast] syntax trees.
+
+## Extending the parser
+
+See [`micromark`][micromark] and [`mdast-util-from-markdown`][from-markdown].
+Then create a wrapper plugin such as [`remark-gfm`][gfm].
+
+## Security
+
+As Markdown is sometimes used for HTML, and improper use of HTML can open you up
+to a [cross-site scripting (XSS)][xss] attack, use of remark can also be unsafe.
+When going to HTML, use remark in combination with the [**rehype**][rehype]
+ecosystem, and use [`rehype-sanitize`][sanitize] to make the tree safe.
+
+Use of remark plugins could also open you up to other attacks.
+Carefully assess each plugin and the risks involved in using them.
+
+## Contribute
+
+See [`contributing.md`][contributing] in [`remarkjs/.github`][health] for ways
+to get started.
+See [`support.md`][support] for ways to get help.
+Ideas for new plugins and tools can be posted in [`remarkjs/ideas`][ideas].
+
+A curated list of awesome remark resources can be found in [**awesome
+remark**][awesome].
+
+This project has a [code of conduct][coc].
+By interacting with this repository, organization, or community you agree to
+abide by its terms.
+
+## Sponsor
+
+Support this effort and give back by sponsoring on [OpenCollective][collective]!
+
+<!--lint ignore no-html-->
+
+<table>
+<tr valign="middle">
+<td width="20%" align="center" colspan="2">
+  <a href="https://www.gatsbyjs.org">Gatsby</a> 🥇<br><br>
+  <a href="https://www.gatsbyjs.org"><img src="https://avatars1.githubusercontent.com/u/12551863?s=256&v=4" width="128"></a>
+</td>
+<td width="20%" align="center" colspan="2">
+  <a href="https://vercel.com">Vercel</a> 🥇<br><br>
+  <a href="https://vercel.com"><img src="https://avatars1.githubusercontent.com/u/14985020?s=256&v=4" width="128"></a>
+</td>
+<td width="20%" align="center" colspan="2">
+  <a href="https://www.netlify.com">Netlify</a><br><br>
+  <!--OC has a sharper image-->
+  <a href="https://www.netlify.com"><img src="https://images.opencollective.com/netlify/4087de2/logo/256.png" width="128"></a>
+</td>
+<td width="10%" align="center">
+  <a href="https://www.holloway.com">Holloway</a><br><br>
+  <a href="https://www.holloway.com"><img src="https://avatars1.githubusercontent.com/u/35904294?s=128&v=4" width="64"></a>
+</td>
+<td width="10%" align="center">
+  <a href="https://themeisle.com">ThemeIsle</a><br><br>
+  <a href="https://themeisle.com"><img src="https://avatars1.githubusercontent.com/u/58979018?s=128&v=4" width="64"></a>
+</td>
+<td width="10%" align="center">
+  <a href="https://boosthub.io">Boost Hub</a><br><br>
+  <a href="https://boosthub.io"><img src="https://images.opencollective.com/boosthub/6318083/logo/128.png" width="64"></a>
+</td>
+<td width="10%" align="center">
+  <a href="https://expo.io">Expo</a><br><br>
+  <a href="https://expo.io"><img src="https://avatars1.githubusercontent.com/u/12504344?s=128&v=4" width="64"></a>
+</td>
+</tr>
+<tr valign="middle">
+<td width="100%" align="center" colspan="10">
+  <br>
+  <a href="https://opencollective.com/unified"><strong>You?</strong></a>
+  <br><br>
+</td>
+</tr>
+</table>
+
+## License
+
+[MIT][license] © [Titus Wormer][author]
+
+<!-- Definitions -->
+
+[build-badge]: https://img.shields.io/travis/remarkjs/remark.svg
+
+[build]: https://travis-ci.org/remarkjs/remark
+
+[coverage-badge]: https://img.shields.io/codecov/c/github/remarkjs/remark.svg
+
+[coverage]: https://codecov.io/github/remarkjs/remark
+
+[downloads-badge]: https://img.shields.io/npm/dm/remark-parse.svg
+
+[downloads]: https://www.npmjs.com/package/remark-parse
+
+[size-badge]: https://img.shields.io/bundlephobia/minzip/remark-parse.svg
+
+[size]: https://bundlephobia.com/result?p=remark-parse
+
+[sponsors-badge]: https://opencollective.com/unified/sponsors/badge.svg
+
+[backers-badge]: https://opencollective.com/unified/backers/badge.svg
+
+[collective]: https://opencollective.com/unified
+
+[chat-badge]: https://img.shields.io/badge/chat-discussions-success.svg
+
+[chat]: https://github.com/remarkjs/remark/discussions
+
+[health]: https://github.com/remarkjs/.github
+
+[contributing]: https://github.com/remarkjs/.github/blob/HEAD/contributing.md
+
+[support]: https://github.com/remarkjs/.github/blob/HEAD/support.md
+
+[coc]: https://github.com/remarkjs/.github/blob/HEAD/code-of-conduct.md
+
+[ideas]: https://github.com/remarkjs/ideas
+
+[awesome]: https://github.com/remarkjs/awesome-remark
+
+[license]: https://github.com/remarkjs/remark/blob/main/license
+
+[author]: https://wooorm.com
+
+[npm]: https://docs.npmjs.com/cli/install
+
+[unified]: https://github.com/unifiedjs/unified
+
+[remark]: https://github.com/remarkjs/remark/tree/main/packages/remark
+
+[mdast]: https://github.com/syntax-tree/mdast
+
+[parser]: https://github.com/unifiedjs/unified#processorparser
+
+[extend]: #extending-the-parser
+
+[xss]: https://en.wikipedia.org/wiki/Cross-site_scripting
+
+[rehype]: https://github.com/rehypejs/rehype
+
+[sanitize]: https://github.com/rehypejs/rehype-sanitize
+
+[micromark]: https://github.com/micromark/micromark
+
+[from-markdown]: https://github.com/syntax-tree/mdast-util-from-markdown
+
+[gfm]: https://github.com/remarkjs/remark-gfm
+
+-----------
+
+The following NPM package may be included in this product:
+
+ - repeat-string@1.6.1
+
+This package contains the following license and notice below:
+
+The MIT License (MIT)
+
+Copyright (c) 2014-2016, Jon Schlinkert.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -6855,7 +2055,7 @@ THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - resolve-protobuf-schema@2.1.0
 
@@ -6885,7 +2085,7 @@ THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - rw@1.3.3
 
@@ -6920,39 +2120,9 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
- - sade@1.8.1
-
-This package contains the following license and notice below:
-
-The MIT License (MIT)
-
-Copyright (c) Luke Edwards <luke.edwards05@gmail.com> (https://lukeed.com)
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
------------
-
-The following npm package may be included in this product:
-
- - style-to-object@0.4.1
+ - style-to-object@0.3.0
 
 This package contains the following license and notice below:
 
@@ -6981,7 +2151,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - supercluster@7.1.5
 
@@ -7005,7 +2175,7 @@ THIS SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - tinyqueue@2.0.3
 
@@ -7029,9 +2199,9 @@ THIS SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
- - trough@2.1.0
+ - trough@1.0.5
 
 This package contains the following license and notice below:
 
@@ -7059,10 +2229,10 @@ THE SOFTWARE.
 
 -----------
 
-The following npm packages may be included in this product:
+The following NPM packages may be included in this product:
 
- - unified@10.1.2
- - vfile@5.3.7
+ - unified@9.2.2
+ - vfile@4.2.1
 
 These packages each contain the following license and notice below:
 
@@ -7090,9 +2260,39 @@ THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
- - unist-util-is@5.2.1
+ - unist-builder@2.0.3
+
+This package contains the following license and notice below:
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Eugene Sharygin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+-----------
+
+The following NPM package may be included in this product:
+
+ - unist-util-is@4.1.0
 
 This package contains the following license and notice below:
 
@@ -7121,9 +2321,9 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
- - vfile-message@3.1.4
+ - vfile-message@2.0.4
 
 This package contains the following license and notice below:
 
@@ -7152,7 +2352,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - vt-pbf@3.1.3
 
@@ -7214,5 +2414,33 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -----------
 
-This file was generated with the generate-license-file npm package!
-https://www.npmjs.com/package/generate-license-file
+The following NPM package may be included in this product:
+
+ - xtend@4.0.2
+
+This package contains the following license and notice below:
+
+The MIT License (MIT)
+Copyright (c) 2012-2014 Raynos.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+-----------
+
+This file was generated with generate-license-file! https://www.npmjs.com/package/generate-license-file

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,10 +17,10 @@
         "@lexical/table": "^0.8.0",
         "lexical": "^0.8.0",
         "mapbox-gl": "^2.11.0",
-        "react-markdown": "^8.0.5",
-        "rehype-raw": "^6.1.1",
-        "rehype-sanitize": "^5.0.1",
-        "remark-gfm": "^3.0.1"
+        "react-markdown": "^6.0.3",
+        "rehype-raw": "^5.0.0",
+        "rehype-sanitize": "^4.0.0",
+        "remark-gfm": "^1.0.0"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.14.7",
@@ -59,7 +59,7 @@
         "tailwindcss": "^3.2.4",
         "ts-jest": "^29.0.3",
         "typescript": "^4.8.4",
-        "unified": "^10.1.2"
+        "unified": "^9.0.0"
       },
       "peerDependencies": {
         "react": "^17 || ^18",
@@ -4447,25 +4447,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@mdx-js/mdx/node_modules/bail": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
-      "integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==",
-      "dev": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/@mdx-js/mdx/node_modules/is-plain-obj": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@mdx-js/mdx/node_modules/semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -4482,16 +4463,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@mdx-js/mdx/node_modules/trough": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
-      "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
-      "dev": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/@mdx-js/mdx/node_modules/unified": {
@@ -7583,14 +7554,6 @@
         "@babel/types": "^7.3.0"
       }
     },
-    "node_modules/@types/debug": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
-      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
-      "dependencies": {
-        "@types/ms": "*"
-      }
-    },
     "node_modules/@types/estree": {
       "version": "0.0.51",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
@@ -7796,11 +7759,6 @@
       "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
       "dev": true
     },
-    "node_modules/@types/ms": {
-      "version": "0.7.31",
-      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
-      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
-    },
     "node_modules/@types/node": {
       "version": "18.11.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
@@ -7838,8 +7796,7 @@
     "node_modules/@types/parse5": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-5.0.3.tgz",
-      "integrity": "sha512-kUNnecmtkunAoQ3CnjmMkzNU/gtxG8guhi+Fk2U/kOpIKjIMKnXGp4IJCgQJrXSgMsWYimYG4TGjz/UzbGEBTw==",
-      "dev": true
+      "integrity": "sha512-kUNnecmtkunAoQ3CnjmMkzNU/gtxG8guhi+Fk2U/kOpIKjIMKnXGp4IJCgQJrXSgMsWYimYG4TGjz/UzbGEBTw=="
     },
     "node_modules/@types/prettier": {
       "version": "2.7.1",
@@ -7856,7 +7813,8 @@
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
+      "dev": true
     },
     "node_modules/@types/qs": {
       "version": "6.9.7",
@@ -9836,9 +9794,9 @@
       }
     },
     "node_modules/bail": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
-      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
+      "integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -10660,7 +10618,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.1.0.tgz",
       "integrity": "sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==",
-      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -10693,7 +10650,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
       "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
-      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -10703,7 +10659,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
       "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
-      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -10713,7 +10668,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
       "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
-      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -11110,7 +11064,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz",
       "integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==",
-      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -12118,27 +12071,6 @@
       "integrity": "sha512-ic1yEvwT6GuvaYwBLLY6/aFFgjZdySKTE8en/fkU3QICTmRtgtSlFn0u0BXN06InZwtfCelR7j8LRiDI/02iGA==",
       "dev": true
     },
-    "node_modules/decode-named-character-reference": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.0.2.tgz",
-      "integrity": "sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==",
-      "dependencies": {
-        "character-entities": "^2.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/decode-named-character-reference/node_modules/character-entities": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
-      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
@@ -12336,14 +12268,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/dequal": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/des.js": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
@@ -12434,14 +12358,6 @@
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
       "dev": true
-    },
-    "node_modules/diff": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
-      "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
-      "engines": {
-        "node": ">=0.3.1"
-      }
     },
     "node_modules/diff-sequences": {
       "version": "29.2.0",
@@ -15807,7 +15723,6 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/hast-to-hyperscript/-/hast-to-hyperscript-9.0.1.tgz",
       "integrity": "sha512-zQgLKqF+O2F72S1aa4y2ivxzSlko3MAvxkwG8ehGmNiqd98BIN3JM1rAJPmplEyLmGLO2QZYJtIneOSZ2YbJuA==",
-      "dev": true,
       "dependencies": {
         "@types/unist": "^2.0.3",
         "comma-separated-tokens": "^1.0.0",
@@ -15826,7 +15741,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-6.0.1.tgz",
       "integrity": "sha512-jeJUWiN5pSxW12Rh01smtVkZgZr33wBokLzKLwinYOUfSzm1Nl/c3GUGebDyOKjdsRgMvoVbV0VpAcpjF4NrJA==",
-      "dev": true,
       "dependencies": {
         "@types/parse5": "^5.0.0",
         "hastscript": "^6.0.0",
@@ -15844,7 +15758,6 @@
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.5.tgz",
       "integrity": "sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ==",
-      "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
@@ -15873,11 +15786,11 @@
       }
     },
     "node_modules/hast-util-sanitize": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-4.1.0.tgz",
-      "integrity": "sha512-Hd9tU0ltknMGRDv+d6Ro/4XKzBqQnP/EZrpiTbpFYfXv/uOhWeKc+2uajcbEvAEH98VZd7eII2PiXm13RihnLw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-3.0.2.tgz",
+      "integrity": "sha512-+2I0x2ZCAyiZOO/sb4yNLFmdwPBnyJ4PBkVTUMKMqBwYNA+lXSgOmoRXlJFazoyid9QPogRRKgKhVEodv181sA==",
       "dependencies": {
-        "@types/hast": "^2.0.0"
+        "xtend": "^4.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -15888,7 +15801,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-6.0.0.tgz",
       "integrity": "sha512-Lu5m6Lgm/fWuz8eWnrKezHtVY83JeRGaNQ2kn9aJgqaxvVkFCZQBEhgodZUDUvoodgyROHDb3r5IxAEdl6suJQ==",
-      "dev": true,
       "dependencies": {
         "hast-to-hyperscript": "^9.0.0",
         "property-information": "^5.0.0",
@@ -15901,20 +15813,10 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/hast-util-whitespace": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-2.0.1.tgz",
-      "integrity": "sha512-nAxA0v8+vXSBDt3AnRUNjyRIQ0rD+ntpbAp4LnPkumc5M9yUbSMa4XDU9Q6etY4f1Wp4bNgvc1yjiZtsTTrSng==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/hastscript": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-6.0.0.tgz",
       "integrity": "sha512-nDM6bvd7lIqDUiYEiu5Sl/+6ReP0BMk/2f4U/Rooccxkj0P5nm+acM5PrGJ/t5I8qPGiqZSE6hVAwZEdZIvP4w==",
-      "dev": true,
       "dependencies": {
         "@types/hast": "^2.0.0",
         "comma-separated-tokens": "^1.0.0",
@@ -16035,7 +15937,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-1.0.5.tgz",
       "integrity": "sha512-uE/TxKuyNIcx44cIWnjr/rfIATDH7ZaOMmstu0CwhFG1Dunhlp4OC6/NMbhiwoq5BpW0ubi303qnEk/PZj614w==",
-      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -16472,7 +16373,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
       "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
-      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -16482,7 +16382,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
       "integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
-      "dev": true,
       "dependencies": {
         "is-alphabetical": "^1.0.0",
         "is-decimal": "^1.0.0"
@@ -16649,7 +16548,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
       "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
-      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -16759,7 +16657,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
       "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
-      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -16838,14 +16735,11 @@
       }
     },
     "node_modules/is-plain-obj": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
-      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=8"
       }
     },
     "node_modules/is-plain-object": {
@@ -21795,9 +21689,9 @@
       "dev": true
     },
     "node_modules/longest-streak": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
-      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.4.tgz",
+      "integrity": "sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -21971,9 +21865,12 @@
       }
     },
     "node_modules/markdown-table": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.3.tgz",
-      "integrity": "sha512-Z1NL3Tb1M9wH4XESsCDEksWoKTdlUafKc4pt0GRwjUyXaCFZ+dc3g2erqB6zm3szA2IUSi7VnPI+o/9jnxh9hw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
+      "integrity": "sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==",
+      "dependencies": {
+        "repeat-string": "^1.0.0"
+      },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -22007,7 +21904,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-4.0.0.tgz",
       "integrity": "sha512-k8AJ6aNnUkB7IE+5azR9h81O5EQ/cTDXtWdMq9Kk5KcEW/8ritU5CeLg/9HhOC++nALHBlaogJ5jz0Ybk3kPMQ==",
-      "dev": true,
       "dependencies": {
         "unist-util-visit": "^2.0.0"
       },
@@ -22017,14 +21913,13 @@
       }
     },
     "node_modules/mdast-util-find-and-replace": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-2.2.2.tgz",
-      "integrity": "sha512-MTtdFRz/eMDHXzeK6W3dO7mXUlF82Gom4y0oOgvHhh/HXZAGvIQDUvQ0SuUx+j2tv44b8xTHOm8K/9OoRFnXKw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-1.1.1.tgz",
+      "integrity": "sha512-9cKl33Y21lyckGzpSmEQnIDjEfeeWelN5s1kUW1LwdB0Fkuq2u+4GdqcGEygYxJE8GVqCl0741bYXHgamfWAZA==",
       "dependencies": {
-        "@types/mdast": "^3.0.0",
-        "escape-string-regexp": "^5.0.0",
-        "unist-util-is": "^5.0.0",
-        "unist-util-visit-parents": "^5.0.0"
+        "escape-string-regexp": "^4.0.0",
+        "unist-util-is": "^4.0.0",
+        "unist-util-visit-parents": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -22032,100 +21927,26 @@
       }
     },
     "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "engines": {
-        "node": ">=12"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/mdast-util-find-and-replace/node_modules/unist-util-is": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
-      "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
-      "dependencies": {
-        "@types/unist": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-find-and-replace/node_modules/unist-util-visit-parents": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
-      "integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "unist-util-is": "^5.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-from-markdown": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.3.0.tgz",
-      "integrity": "sha512-HN3W1gRIuN/ZW295c7zi7g9lVBllMgZE40RxCX37wrTPWXCWtpvOZdfnuK+1WNpvZje6XuJeI3Wnb4TJEUem+g==",
-      "dependencies": {
-        "@types/mdast": "^3.0.0",
-        "@types/unist": "^2.0.0",
-        "decode-named-character-reference": "^1.0.0",
-        "mdast-util-to-string": "^3.1.0",
-        "micromark": "^3.0.0",
-        "micromark-util-decode-numeric-character-reference": "^1.0.0",
-        "micromark-util-decode-string": "^1.0.0",
-        "micromark-util-normalize-identifier": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.0",
-        "unist-util-stringify-position": "^3.0.0",
-        "uvu": "^0.5.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-from-markdown/node_modules/mdast-util-to-string": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.1.1.tgz",
-      "integrity": "sha512-tGvhT94e+cVnQt8JWE9/b3cUQZWS732TJxXHktvP+BYo62PpYD53Ls/6cC60rW21dW+txxiM4zMdc6abASvZKA==",
-      "dependencies": {
-        "@types/mdast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-from-markdown/node_modules/unist-util-stringify-position": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
-      "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
-      "dependencies": {
-        "@types/unist": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/mdast-util-gfm": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-2.0.2.tgz",
-      "integrity": "sha512-qvZ608nBppZ4icQlhQQIAdc6S3Ffj9RGmzwUKUWuEICFnd1LVkN3EktF7ZHAgfcEdvZB5owU9tQgt99e2TlLjg==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-0.1.2.tgz",
+      "integrity": "sha512-NNkhDx/qYcuOWB7xHUGWZYVXvjPFFd6afg6/e2g+SV4r9q5XUcCbV4Wfa3DLYIiD+xAEZc6K4MGaE/m0KDcPwQ==",
       "dependencies": {
-        "mdast-util-from-markdown": "^1.0.0",
-        "mdast-util-gfm-autolink-literal": "^1.0.0",
-        "mdast-util-gfm-footnote": "^1.0.0",
-        "mdast-util-gfm-strikethrough": "^1.0.0",
-        "mdast-util-gfm-table": "^1.0.0",
-        "mdast-util-gfm-task-list-item": "^1.0.0",
-        "mdast-util-to-markdown": "^1.0.0"
+        "mdast-util-gfm-autolink-literal": "^0.1.0",
+        "mdast-util-gfm-strikethrough": "^0.2.0",
+        "mdast-util-gfm-table": "^0.1.0",
+        "mdast-util-gfm-task-list-item": "^0.1.0",
+        "mdast-util-to-markdown": "^0.6.1"
       },
       "funding": {
         "type": "opencollective",
@@ -22133,37 +21954,13 @@
       }
     },
     "node_modules/mdast-util-gfm-autolink-literal": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-1.0.3.tgz",
-      "integrity": "sha512-My8KJ57FYEy2W2LyNom4n3E7hKTuQk/0SES0u16tjA9Z3oFkF4RrC/hPAPgjlSpezsOvI8ObcXcElo92wn5IGA==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-0.1.3.tgz",
+      "integrity": "sha512-GjmLjWrXg1wqMIO9+ZsRik/s7PLwTaeCHVB7vRxUwLntZc8mzmTsLVr6HW1yLokcnhfURsn5zmSVdi3/xWWu1A==",
       "dependencies": {
-        "@types/mdast": "^3.0.0",
-        "ccount": "^2.0.0",
-        "mdast-util-find-and-replace": "^2.0.0",
-        "micromark-util-character": "^1.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-gfm-autolink-literal/node_modules/ccount": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
-      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/mdast-util-gfm-footnote": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-1.0.2.tgz",
-      "integrity": "sha512-56D19KOGbE00uKVj3sgIykpwKL179QsVFwx/DCW0u/0+URsryacI4MAdNJl0dh+u2PSsD9FtxPFbHCzJ78qJFQ==",
-      "dependencies": {
-        "@types/mdast": "^3.0.0",
-        "mdast-util-to-markdown": "^1.3.0",
-        "micromark-util-normalize-identifier": "^1.0.0"
+        "ccount": "^1.0.0",
+        "mdast-util-find-and-replace": "^1.1.0",
+        "micromark": "^2.11.3"
       },
       "funding": {
         "type": "opencollective",
@@ -22171,12 +21968,11 @@
       }
     },
     "node_modules/mdast-util-gfm-strikethrough": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-1.0.3.tgz",
-      "integrity": "sha512-DAPhYzTYrRcXdMjUtUjKvW9z/FNAMTdU0ORyMcbmkwYNbKocDpdk+PX1L1dQgOID/+vVs1uBQ7ElrBQfZ0cuiQ==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-0.2.3.tgz",
+      "integrity": "sha512-5OQLXpt6qdbttcDG/UxYY7Yjj3e8P7X16LzvpX8pIQPYJ/C2Z1qFGMmcw+1PZMUM3Z8wt8NRfYTvCni93mgsgA==",
       "dependencies": {
-        "@types/mdast": "^3.0.0",
-        "mdast-util-to-markdown": "^1.3.0"
+        "mdast-util-to-markdown": "^0.6.0"
       },
       "funding": {
         "type": "opencollective",
@@ -22184,14 +21980,12 @@
       }
     },
     "node_modules/mdast-util-gfm-table": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-1.0.7.tgz",
-      "integrity": "sha512-jjcpmNnQvrmN5Vx7y7lEc2iIOEytYv7rTvu+MeyAsSHTASGCCRA79Igg2uKssgOs1i1po8s3plW0sTu1wkkLGg==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-0.1.6.tgz",
+      "integrity": "sha512-j4yDxQ66AJSBwGkbpFEp9uG/LS1tZV3P33fN1gkyRB2LoRL+RR3f76m0HPHaby6F4Z5xr9Fv1URmATlRRUIpRQ==",
       "dependencies": {
-        "@types/mdast": "^3.0.0",
-        "markdown-table": "^3.0.0",
-        "mdast-util-from-markdown": "^1.0.0",
-        "mdast-util-to-markdown": "^1.3.0"
+        "markdown-table": "^2.0.0",
+        "mdast-util-to-markdown": "~0.6.0"
       },
       "funding": {
         "type": "opencollective",
@@ -22199,37 +21993,11 @@
       }
     },
     "node_modules/mdast-util-gfm-task-list-item": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-1.0.2.tgz",
-      "integrity": "sha512-PFTA1gzfp1B1UaiJVyhJZA1rm0+Tzn690frc/L8vNX1Jop4STZgOE6bxUhnzdVSB+vm2GU1tIsuQcA9bxTQpMQ==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-0.1.6.tgz",
+      "integrity": "sha512-/d51FFIfPsSmCIRNp7E6pozM9z1GYPIkSy1urQ8s/o4TC22BZ7DqfHFWiqBD23bc7J3vV1Fc9O4QIHBlfuit8A==",
       "dependencies": {
-        "@types/mdast": "^3.0.0",
-        "mdast-util-to-markdown": "^1.3.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-phrasing": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-3.0.1.tgz",
-      "integrity": "sha512-WmI1gTXUBJo4/ZmSk79Wcb2HcjPJBzM1nlI/OUWA8yk2X9ik3ffNbBGsU+09BFmXaL1IBb9fiuvq6/KMiNycSg==",
-      "dependencies": {
-        "@types/mdast": "^3.0.0",
-        "unist-util-is": "^5.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-phrasing/node_modules/unist-util-is": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
-      "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
-      "dependencies": {
-        "@types/unist": "^2.0.0"
+        "mdast-util-to-markdown": "~0.6.0"
       },
       "funding": {
         "type": "opencollective",
@@ -22257,18 +22025,16 @@
       }
     },
     "node_modules/mdast-util-to-markdown": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-1.5.0.tgz",
-      "integrity": "sha512-bbv7TPv/WC49thZPg3jXuqzuvI45IL2EVAr/KxF0BSdHsU0ceFHOmwQn6evxAh1GaoK/6GQ1wp4R4oW2+LFL/A==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-0.6.5.tgz",
+      "integrity": "sha512-XeV9sDE7ZlOQvs45C9UKMtfTcctcaj/pGwH8YLbMHoMOXNNCn2LsqVQOqrF1+/NU8lKDAqozme9SCXWyo9oAcQ==",
       "dependencies": {
-        "@types/mdast": "^3.0.0",
         "@types/unist": "^2.0.0",
-        "longest-streak": "^3.0.0",
-        "mdast-util-phrasing": "^3.0.0",
-        "mdast-util-to-string": "^3.0.0",
-        "micromark-util-decode-string": "^1.0.0",
-        "unist-util-visit": "^4.0.0",
-        "zwitch": "^2.0.0"
+        "longest-streak": "^2.0.0",
+        "mdast-util-to-string": "^2.0.0",
+        "parse-entities": "^2.0.0",
+        "repeat-string": "^1.0.0",
+        "zwitch": "^1.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -22276,63 +22042,12 @@
       }
     },
     "node_modules/mdast-util-to-markdown/node_modules/mdast-util-to-string": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.1.1.tgz",
-      "integrity": "sha512-tGvhT94e+cVnQt8JWE9/b3cUQZWS732TJxXHktvP+BYo62PpYD53Ls/6cC60rW21dW+txxiM4zMdc6abASvZKA==",
-      "dependencies": {
-        "@types/mdast": "^3.0.0"
-      },
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz",
+      "integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-to-markdown/node_modules/unist-util-is": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
-      "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
-      "dependencies": {
-        "@types/unist": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-to-markdown/node_modules/unist-util-visit": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.2.tgz",
-      "integrity": "sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==",
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "unist-util-is": "^5.0.0",
-        "unist-util-visit-parents": "^5.1.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-to-markdown/node_modules/unist-util-visit-parents": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
-      "integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "unist-util-is": "^5.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-to-markdown/node_modules/zwitch": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
-      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/mdast-util-to-string": {
@@ -22348,8 +22063,7 @@
     "node_modules/mdurl": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
-      "dev": true
+      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g=="
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -22561,9 +22275,9 @@
       "dev": true
     },
     "node_modules/micromark": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/micromark/-/micromark-3.1.0.tgz",
-      "integrity": "sha512-6Mj0yHLdUZjHnOPgr5xfWIMqMWS12zDN6iws9SLuSz76W8jTtAv24MN4/CL7gJrl5vtxGInkkqDv/JIoRsQOvA==",
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.4.tgz",
+      "integrity": "sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -22575,71 +22289,21 @@
         }
       ],
       "dependencies": {
-        "@types/debug": "^4.0.0",
         "debug": "^4.0.0",
-        "decode-named-character-reference": "^1.0.0",
-        "micromark-core-commonmark": "^1.0.1",
-        "micromark-factory-space": "^1.0.0",
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-chunked": "^1.0.0",
-        "micromark-util-combine-extensions": "^1.0.0",
-        "micromark-util-decode-numeric-character-reference": "^1.0.0",
-        "micromark-util-encode": "^1.0.0",
-        "micromark-util-normalize-identifier": "^1.0.0",
-        "micromark-util-resolve-all": "^1.0.0",
-        "micromark-util-sanitize-uri": "^1.0.0",
-        "micromark-util-subtokenize": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.1",
-        "uvu": "^0.5.0"
-      }
-    },
-    "node_modules/micromark-core-commonmark": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-1.0.6.tgz",
-      "integrity": "sha512-K+PkJTxqjFfSNkfAhp4GB+cZPfQd6dxtTXnf+RjZOV7T4EEXnvgzOcnp+eSTmpGk9d1S9sL6/lqrgSNn/s0HZA==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "dependencies": {
-        "decode-named-character-reference": "^1.0.0",
-        "micromark-factory-destination": "^1.0.0",
-        "micromark-factory-label": "^1.0.0",
-        "micromark-factory-space": "^1.0.0",
-        "micromark-factory-title": "^1.0.0",
-        "micromark-factory-whitespace": "^1.0.0",
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-chunked": "^1.0.0",
-        "micromark-util-classify-character": "^1.0.0",
-        "micromark-util-html-tag-name": "^1.0.0",
-        "micromark-util-normalize-identifier": "^1.0.0",
-        "micromark-util-resolve-all": "^1.0.0",
-        "micromark-util-subtokenize": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.1",
-        "uvu": "^0.5.0"
+        "parse-entities": "^2.0.0"
       }
     },
     "node_modules/micromark-extension-gfm": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-2.0.1.tgz",
-      "integrity": "sha512-p2sGjajLa0iYiGQdT0oelahRYtMWvLjy8J9LOCxzIQsllMCGLbsLW+Nc+N4vi02jcRJvedVJ68cjelKIO6bpDA==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-0.3.3.tgz",
+      "integrity": "sha512-oVN4zv5/tAIA+l3GbMi7lWeYpJ14oQyJ3uEim20ktYFAcfX1x3LNlFGGlmrZHt7u9YlKExmyJdDGaTt6cMSR/A==",
       "dependencies": {
-        "micromark-extension-gfm-autolink-literal": "^1.0.0",
-        "micromark-extension-gfm-footnote": "^1.0.0",
-        "micromark-extension-gfm-strikethrough": "^1.0.0",
-        "micromark-extension-gfm-table": "^1.0.0",
-        "micromark-extension-gfm-tagfilter": "^1.0.0",
-        "micromark-extension-gfm-task-list-item": "^1.0.0",
-        "micromark-util-combine-extensions": "^1.0.0",
-        "micromark-util-types": "^1.0.0"
+        "micromark": "~2.11.0",
+        "micromark-extension-gfm-autolink-literal": "~0.5.0",
+        "micromark-extension-gfm-strikethrough": "~0.6.5",
+        "micromark-extension-gfm-table": "~0.4.0",
+        "micromark-extension-gfm-tagfilter": "~0.3.0",
+        "micromark-extension-gfm-task-list-item": "~0.3.0"
       },
       "funding": {
         "type": "opencollective",
@@ -22647,34 +22311,11 @@
       }
     },
     "node_modules/micromark-extension-gfm-autolink-literal": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-1.0.3.tgz",
-      "integrity": "sha512-i3dmvU0htawfWED8aHMMAzAVp/F0Z+0bPh3YrbTPPL1v4YAlCZpy5rBO5p0LPYiZo0zFVkoYh7vDU7yQSiCMjg==",
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-0.5.7.tgz",
+      "integrity": "sha512-ePiDGH0/lhcngCe8FtH4ARFoxKTUelMp4L7Gg2pujYD5CSMb9PbblnyL+AAMud/SNMyusbS2XDSiPIRcQoNFAw==",
       "dependencies": {
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-sanitize-uri": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.0",
-        "uvu": "^0.5.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm-footnote": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-1.0.4.tgz",
-      "integrity": "sha512-E/fmPmDqLiMUP8mLJ8NbJWJ4bTw6tS+FEQS8CcuDtZpILuOb2kjLqPEeAePF1djXROHXChM/wPJw0iS4kHCcIg==",
-      "dependencies": {
-        "micromark-core-commonmark": "^1.0.0",
-        "micromark-factory-space": "^1.0.0",
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-normalize-identifier": "^1.0.0",
-        "micromark-util-sanitize-uri": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.0",
-        "uvu": "^0.5.0"
+        "micromark": "~2.11.3"
       },
       "funding": {
         "type": "opencollective",
@@ -22682,16 +22323,11 @@
       }
     },
     "node_modules/micromark-extension-gfm-strikethrough": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-1.0.4.tgz",
-      "integrity": "sha512-/vjHU/lalmjZCT5xt7CcHVJGq8sYRm80z24qAKXzaHzem/xsDYb2yLL+NNVbYvmpLx3O7SYPuGL5pzusL9CLIQ==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-0.6.5.tgz",
+      "integrity": "sha512-PpOKlgokpQRwUesRwWEp+fHjGGkZEejj83k9gU5iXCbDG+XBA92BqnRKYJdfqfkrRcZRgGuPuXb7DaK/DmxOhw==",
       "dependencies": {
-        "micromark-util-chunked": "^1.0.0",
-        "micromark-util-classify-character": "^1.0.0",
-        "micromark-util-resolve-all": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.0",
-        "uvu": "^0.5.0"
+        "micromark": "~2.11.0"
       },
       "funding": {
         "type": "opencollective",
@@ -22699,15 +22335,11 @@
       }
     },
     "node_modules/micromark-extension-gfm-table": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-1.0.5.tgz",
-      "integrity": "sha512-xAZ8J1X9W9K3JTJTUL7G6wSKhp2ZYHrFk5qJgY/4B33scJzE2kpfRL6oiw/veJTbt7jiM/1rngLlOKPWr1G+vg==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-0.4.3.tgz",
+      "integrity": "sha512-hVGvESPq0fk6ALWtomcwmgLvH8ZSVpcPjzi0AjPclB9FsVRgMtGZkUcpE0zgjOCFAznKepF4z3hX8z6e3HODdA==",
       "dependencies": {
-        "micromark-factory-space": "^1.0.0",
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.0",
-        "uvu": "^0.5.0"
+        "micromark": "~2.11.0"
       },
       "funding": {
         "type": "opencollective",
@@ -22715,387 +22347,25 @@
       }
     },
     "node_modules/micromark-extension-gfm-tagfilter": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-1.0.1.tgz",
-      "integrity": "sha512-Ty6psLAcAjboRa/UKUbbUcwjVAv5plxmpUTy2XC/3nJFL37eHej8jrHrRzkqcpipJliuBH30DTs7+3wqNcQUVA==",
-      "dependencies": {
-        "micromark-util-types": "^1.0.0"
-      },
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-0.3.0.tgz",
+      "integrity": "sha512-9GU0xBatryXifL//FJH+tAZ6i240xQuFrSL7mYi8f4oZSbc+NvXjkrHemeYP0+L4ZUT+Ptz3b95zhUZnMtoi/Q==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-extension-gfm-task-list-item": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-1.0.3.tgz",
-      "integrity": "sha512-PpysK2S1Q/5VXi72IIapbi/jliaiOFzv7THH4amwXeYXLq3l1uo8/2Be0Ac1rEwK20MQEsGH2ltAZLNY2KI/0Q==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-0.3.3.tgz",
+      "integrity": "sha512-0zvM5iSLKrc/NQl84pZSjGo66aTGd57C1idmlWmE87lkMcXrTxg1uXa/nXomxJytoje9trP0NDLvw4bZ/Z/XCQ==",
       "dependencies": {
-        "micromark-factory-space": "^1.0.0",
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.0",
-        "uvu": "^0.5.0"
+        "micromark": "~2.11.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
-    },
-    "node_modules/micromark-factory-destination": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-1.0.0.tgz",
-      "integrity": "sha512-eUBA7Rs1/xtTVun9TmV3gjfPz2wEwgK5R5xcbIM5ZYAtvGF6JkyaDsj0agx8urXnO31tEO6Ug83iVH3tdedLnw==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "dependencies": {
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.0"
-      }
-    },
-    "node_modules/micromark-factory-label": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-1.0.2.tgz",
-      "integrity": "sha512-CTIwxlOnU7dEshXDQ+dsr2n+yxpP0+fn271pu0bwDIS8uqfFcumXpj5mLn3hSC8iw2MUr6Gx8EcKng1dD7i6hg==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "dependencies": {
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.0",
-        "uvu": "^0.5.0"
-      }
-    },
-    "node_modules/micromark-factory-space": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-1.0.0.tgz",
-      "integrity": "sha512-qUmqs4kj9a5yBnk3JMLyjtWYN6Mzfcx8uJfi5XAveBniDevmZasdGBba5b4QsvRcAkmvGo5ACmSUmyGiKTLZew==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "dependencies": {
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-types": "^1.0.0"
-      }
-    },
-    "node_modules/micromark-factory-title": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-1.0.2.tgz",
-      "integrity": "sha512-zily+Nr4yFqgMGRKLpTVsNl5L4PMu485fGFDOQJQBl2NFpjGte1e86zC0da93wf97jrc4+2G2GQudFMHn3IX+A==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "dependencies": {
-        "micromark-factory-space": "^1.0.0",
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.0",
-        "uvu": "^0.5.0"
-      }
-    },
-    "node_modules/micromark-factory-whitespace": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-1.0.0.tgz",
-      "integrity": "sha512-Qx7uEyahU1lt1RnsECBiuEbfr9INjQTGa6Err+gF3g0Tx4YEviPbqqGKNv/NrBaE7dVHdn1bVZKM/n5I/Bak7A==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "dependencies": {
-        "micromark-factory-space": "^1.0.0",
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.0"
-      }
-    },
-    "node_modules/micromark-util-character": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-1.1.0.tgz",
-      "integrity": "sha512-agJ5B3unGNJ9rJvADMJ5ZiYjBRyDpzKAOk01Kpi1TKhlT1APx3XZk6eN7RtSz1erbWHC2L8T3xLZ81wdtGRZzg==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "dependencies": {
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.0"
-      }
-    },
-    "node_modules/micromark-util-chunked": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-1.0.0.tgz",
-      "integrity": "sha512-5e8xTis5tEZKgesfbQMKRCyzvffRRUX+lK/y+DvsMFdabAicPkkZV6gO+FEWi9RfuKKoxxPwNL+dFF0SMImc1g==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "dependencies": {
-        "micromark-util-symbol": "^1.0.0"
-      }
-    },
-    "node_modules/micromark-util-classify-character": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-1.0.0.tgz",
-      "integrity": "sha512-F8oW2KKrQRb3vS5ud5HIqBVkCqQi224Nm55o5wYLzY/9PwHGXC01tr3d7+TqHHz6zrKQ72Okwtvm/xQm6OVNZA==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "dependencies": {
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.0"
-      }
-    },
-    "node_modules/micromark-util-combine-extensions": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-1.0.0.tgz",
-      "integrity": "sha512-J8H058vFBdo/6+AsjHp2NF7AJ02SZtWaVUjsayNFeAiydTxUwViQPxN0Hf8dp4FmCQi0UUFovFsEyRSUmFH3MA==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "dependencies": {
-        "micromark-util-chunked": "^1.0.0",
-        "micromark-util-types": "^1.0.0"
-      }
-    },
-    "node_modules/micromark-util-decode-numeric-character-reference": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-1.0.0.tgz",
-      "integrity": "sha512-OzO9AI5VUtrTD7KSdagf4MWgHMtET17Ua1fIpXTpuhclCqD8egFWo85GxSGvxgkGS74bEahvtM0WP0HjvV0e4w==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "dependencies": {
-        "micromark-util-symbol": "^1.0.0"
-      }
-    },
-    "node_modules/micromark-util-decode-string": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-1.0.2.tgz",
-      "integrity": "sha512-DLT5Ho02qr6QWVNYbRZ3RYOSSWWFuH3tJexd3dgN1odEuPNxCngTCXJum7+ViRAd9BbdxCvMToPOD/IvVhzG6Q==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "dependencies": {
-        "decode-named-character-reference": "^1.0.0",
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-decode-numeric-character-reference": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0"
-      }
-    },
-    "node_modules/micromark-util-encode": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-1.0.1.tgz",
-      "integrity": "sha512-U2s5YdnAYexjKDel31SVMPbfi+eF8y1U4pfiRW/Y8EFVCy/vgxk/2wWTxzcqE71LHtCuCzlBDRU2a5CQ5j+mQA==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ]
-    },
-    "node_modules/micromark-util-html-tag-name": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-1.1.0.tgz",
-      "integrity": "sha512-BKlClMmYROy9UiV03SwNmckkjn8QHVaWkqoAqzivabvdGcwNGMMMH/5szAnywmsTBUzDsU57/mFi0sp4BQO6dA==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ]
-    },
-    "node_modules/micromark-util-normalize-identifier": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-1.0.0.tgz",
-      "integrity": "sha512-yg+zrL14bBTFrQ7n35CmByWUTFsgst5JhA4gJYoty4Dqzj4Z4Fr/DHekSS5aLfH9bdlfnSvKAWsAgJhIbogyBg==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "dependencies": {
-        "micromark-util-symbol": "^1.0.0"
-      }
-    },
-    "node_modules/micromark-util-resolve-all": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-1.0.0.tgz",
-      "integrity": "sha512-CB/AGk98u50k42kvgaMM94wzBqozSzDDaonKU7P7jwQIuH2RU0TeBqGYJz2WY1UdihhjweivStrJ2JdkdEmcfw==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "dependencies": {
-        "micromark-util-types": "^1.0.0"
-      }
-    },
-    "node_modules/micromark-util-sanitize-uri": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-1.1.0.tgz",
-      "integrity": "sha512-RoxtuSCX6sUNtxhbmsEFQfWzs8VN7cTctmBPvYivo98xb/kDEoTCtJQX5wyzIYEmk/lvNFTat4hL8oW0KndFpg==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "dependencies": {
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-encode": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0"
-      }
-    },
-    "node_modules/micromark-util-subtokenize": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-1.0.2.tgz",
-      "integrity": "sha512-d90uqCnXp/cy4G881Ub4psE57Sf8YD0pim9QdjCRNjfas2M1u6Lbt+XZK9gnHL2XFhnozZiEdCa9CNfXSfQ6xA==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "dependencies": {
-        "micromark-util-chunked": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.0",
-        "uvu": "^0.5.0"
-      }
-    },
-    "node_modules/micromark-util-symbol": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-1.0.1.tgz",
-      "integrity": "sha512-oKDEMK2u5qqAptasDAwWDXq0tG9AssVwAx3E9bBF3t/shRIGsWIRG+cGafs2p/SnDSOecnt6hZPCE2o6lHfFmQ==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ]
-    },
-    "node_modules/micromark-util-types": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-1.0.2.tgz",
-      "integrity": "sha512-DCfg/T8fcrhrRKTPjRrw/5LLvdGV7BHySf/1LOZx7TzWZdYRjogNtyNq885z3nNallwr3QUKARjqvHqX1/7t+w==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ]
     },
     "node_modules/micromatch": {
       "version": "4.0.5",
@@ -23358,14 +22628,6 @@
       },
       "bin": {
         "rimraf": "bin.js"
-      }
-    },
-    "node_modules/mri": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
-      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/ms": {
@@ -24503,7 +23765,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
       "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
-      "dev": true,
       "dependencies": {
         "character-entities": "^1.0.0",
         "character-entities-legacy": "^1.0.0",
@@ -25217,7 +24478,6 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.6.0.tgz",
       "integrity": "sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==",
-      "dev": true,
       "dependencies": {
         "xtend": "^4.0.0"
       },
@@ -25587,29 +24847,26 @@
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
     "node_modules/react-markdown": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-8.0.5.tgz",
-      "integrity": "sha512-jGJolWWmOWAvzf+xMdB9zwStViODyyFQhNB/bwCerbBKmrTmgmA599CGiOlP58OId1IMoIRsA8UdI1Lod4zb5A==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-6.0.3.tgz",
+      "integrity": "sha512-kQbpWiMoBHnj9myLlmZG9T1JdoT/OEyHK7hqM6CqFT14MAkgWiWBUYijLyBmxbntaN6dCDicPcUhWhci1QYodg==",
       "dependencies": {
         "@types/hast": "^2.0.0",
-        "@types/prop-types": "^15.0.0",
-        "@types/unist": "^2.0.0",
-        "comma-separated-tokens": "^2.0.0",
-        "hast-util-whitespace": "^2.0.0",
-        "prop-types": "^15.0.0",
-        "property-information": "^6.0.0",
-        "react-is": "^18.0.0",
-        "remark-parse": "^10.0.0",
-        "remark-rehype": "^10.0.0",
-        "space-separated-tokens": "^2.0.0",
-        "style-to-object": "^0.4.0",
-        "unified": "^10.0.0",
-        "unist-util-visit": "^4.0.0",
-        "vfile": "^5.0.0"
+        "@types/unist": "^2.0.3",
+        "comma-separated-tokens": "^1.0.0",
+        "prop-types": "^15.7.2",
+        "property-information": "^5.3.0",
+        "react-is": "^17.0.0",
+        "remark-parse": "^9.0.0",
+        "remark-rehype": "^8.0.0",
+        "space-separated-tokens": "^1.1.0",
+        "style-to-object": "^0.3.0",
+        "unified": "^9.0.0",
+        "unist-util-visit": "^2.0.0",
+        "vfile": "^4.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -25620,133 +24877,37 @@
         "react": ">=16"
       }
     },
-    "node_modules/react-markdown/node_modules/comma-separated-tokens": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
-      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/react-markdown/node_modules/property-information": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.2.0.tgz",
-      "integrity": "sha512-kma4U7AFCTwpqq5twzC1YVIDXSqg6qQK6JN0smOw8fgRy1OkMi0CYSzFmsy6dnqSenamAtj0CyXMUJ1Mf6oROg==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/react-markdown/node_modules/react-is": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
-    },
-    "node_modules/react-markdown/node_modules/remark-parse": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-10.0.1.tgz",
-      "integrity": "sha512-1fUyHr2jLsVOkhbvPRBJ5zTKZZyD6yZzYaWCS6BPBdQ8vEMBCH+9zNCDA6tET/zHCi/jLqjCWtlJZUPk+DbnFw==",
+    "node_modules/react-markdown/node_modules/mdast-util-from-markdown": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz",
+      "integrity": "sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==",
       "dependencies": {
         "@types/mdast": "^3.0.0",
-        "mdast-util-from-markdown": "^1.0.0",
-        "unified": "^10.0.0"
+        "mdast-util-to-string": "^2.0.0",
+        "micromark": "~2.11.0",
+        "parse-entities": "^2.0.0",
+        "unist-util-stringify-position": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/react-markdown/node_modules/space-separated-tokens": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
-      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/react-markdown/node_modules/style-to-object": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.4.1.tgz",
-      "integrity": "sha512-HFpbb5gr2ypci7Qw+IOhnP2zOU7e77b+rzM+wTzXzfi1PrtBCX0E7Pk4wL4iTLnhzZ+JgEGAhX81ebTg/aYjQw==",
-      "dependencies": {
-        "inline-style-parser": "0.1.1"
-      }
-    },
-    "node_modules/react-markdown/node_modules/unist-util-is": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
-      "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
-      "dependencies": {
-        "@types/unist": "^2.0.0"
-      },
+    "node_modules/react-markdown/node_modules/mdast-util-to-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz",
+      "integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/react-markdown/node_modules/unist-util-stringify-position": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
-      "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
+    "node_modules/react-markdown/node_modules/remark-parse": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-9.0.0.tgz",
+      "integrity": "sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==",
       "dependencies": {
-        "@types/unist": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/react-markdown/node_modules/unist-util-visit": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.2.tgz",
-      "integrity": "sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==",
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "unist-util-is": "^5.0.0",
-        "unist-util-visit-parents": "^5.1.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/react-markdown/node_modules/unist-util-visit-parents": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
-      "integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "unist-util-is": "^5.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/react-markdown/node_modules/vfile": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.7.tgz",
-      "integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "is-buffer": "^2.0.0",
-        "unist-util-stringify-position": "^3.0.0",
-        "vfile-message": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/react-markdown/node_modules/vfile-message": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.4.tgz",
-      "integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "unist-util-stringify-position": "^3.0.0"
+        "mdast-util-from-markdown": "^0.8.0"
       },
       "funding": {
         "type": "opencollective",
@@ -26117,57 +25278,11 @@
       }
     },
     "node_modules/rehype-raw": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-6.1.1.tgz",
-      "integrity": "sha512-d6AKtisSRtDRX4aSPsJGTfnzrX2ZkHQLE5kiUuGOeEoLpbEulFF4hj0mLPbsa+7vmguDKOVVEQdHKDSwoaIDsQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-5.1.0.tgz",
+      "integrity": "sha512-MDvHAb/5mUnif2R+0IPCYJU8WjHa9UzGtM/F4AVy5GixPlDZ1z3HacYy4xojDU+uBa+0X/3PIfyQI26/2ljJNA==",
       "dependencies": {
-        "@types/hast": "^2.0.0",
-        "hast-util-raw": "^7.2.0",
-        "unified": "^10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/rehype-raw/node_modules/@types/parse5": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-6.0.3.tgz",
-      "integrity": "sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g=="
-    },
-    "node_modules/rehype-raw/node_modules/comma-separated-tokens": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
-      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/rehype-raw/node_modules/hast-util-from-parse5": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-7.1.2.tgz",
-      "integrity": "sha512-Nz7FfPBuljzsN3tCQ4kCBKqdNhQE2l0Tn+X1ubgKBPRoiDIu1mL08Cfw4k7q71+Duyaw7DXDN+VTAp4Vh3oCOw==",
-      "dependencies": {
-        "@types/hast": "^2.0.0",
-        "@types/unist": "^2.0.0",
-        "hastscript": "^7.0.0",
-        "property-information": "^6.0.0",
-        "vfile": "^5.0.0",
-        "vfile-location": "^4.0.0",
-        "web-namespaces": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/rehype-raw/node_modules/hast-util-parse-selector": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-3.1.1.tgz",
-      "integrity": "sha512-jdlwBjEexy1oGz0aJ2f4GKMaVKkA9jwjr4MjAAI22E5fM/TXVZHuS5OpONtdeIkRKqAaryQ2E9xNQxijoThSZA==",
-      "dependencies": {
-        "@types/hast": "^2.0.0"
+        "hast-util-raw": "^6.1.0"
       },
       "funding": {
         "type": "opencollective",
@@ -26175,217 +25290,33 @@
       }
     },
     "node_modules/rehype-raw/node_modules/hast-util-raw": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-7.2.3.tgz",
-      "integrity": "sha512-RujVQfVsOrxzPOPSzZFiwofMArbQke6DJjnFfceiEbFh7S05CbPt0cYN+A5YeD3pso0JQk6O1aHBnx9+Pm2uqg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-6.1.0.tgz",
+      "integrity": "sha512-5FoZLDHBpka20OlZZ4I/+RBw5piVQ8iI1doEvffQhx5CbCyTtP8UCq8Tw6NmTAMtXgsQxmhW7Ly8OdFre5/YMQ==",
       "dependencies": {
         "@types/hast": "^2.0.0",
-        "@types/parse5": "^6.0.0",
-        "hast-util-from-parse5": "^7.0.0",
-        "hast-util-to-parse5": "^7.0.0",
-        "html-void-elements": "^2.0.0",
+        "hast-util-from-parse5": "^6.0.0",
+        "hast-util-to-parse5": "^6.0.0",
+        "html-void-elements": "^1.0.0",
         "parse5": "^6.0.0",
-        "unist-util-position": "^4.0.0",
-        "unist-util-visit": "^4.0.0",
-        "vfile": "^5.0.0",
-        "web-namespaces": "^2.0.0",
-        "zwitch": "^2.0.0"
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^2.0.0",
+        "vfile": "^4.0.0",
+        "web-namespaces": "^1.0.0",
+        "xtend": "^4.0.0",
+        "zwitch": "^1.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/rehype-raw/node_modules/hast-util-to-parse5": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-7.1.0.tgz",
-      "integrity": "sha512-YNRgAJkH2Jky5ySkIqFXTQiaqcAtJyVE+D5lkN6CdtOqrnkLfGYYrEcKuHOJZlp+MwjSwuD3fZuawI+sic/RBw==",
-      "dependencies": {
-        "@types/hast": "^2.0.0",
-        "comma-separated-tokens": "^2.0.0",
-        "property-information": "^6.0.0",
-        "space-separated-tokens": "^2.0.0",
-        "web-namespaces": "^2.0.0",
-        "zwitch": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/rehype-raw/node_modules/hastscript": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-7.2.0.tgz",
-      "integrity": "sha512-TtYPq24IldU8iKoJQqvZOuhi5CyCQRAbvDOX0x1eW6rsHSxa/1i2CCiptNTotGHJ3VoHRGmqiv6/D3q113ikkw==",
-      "dependencies": {
-        "@types/hast": "^2.0.0",
-        "comma-separated-tokens": "^2.0.0",
-        "hast-util-parse-selector": "^3.0.0",
-        "property-information": "^6.0.0",
-        "space-separated-tokens": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/rehype-raw/node_modules/html-void-elements": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-2.0.1.tgz",
-      "integrity": "sha512-0quDb7s97CfemeJAnW9wC0hw78MtW7NU3hqtCD75g2vFlDLt36llsYD7uB7SUzojLMP24N5IatXf7ylGXiGG9A==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/rehype-raw/node_modules/property-information": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.2.0.tgz",
-      "integrity": "sha512-kma4U7AFCTwpqq5twzC1YVIDXSqg6qQK6JN0smOw8fgRy1OkMi0CYSzFmsy6dnqSenamAtj0CyXMUJ1Mf6oROg==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/rehype-raw/node_modules/space-separated-tokens": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
-      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/rehype-raw/node_modules/unist-util-is": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
-      "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
-      "dependencies": {
-        "@types/unist": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/rehype-raw/node_modules/unist-util-position": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-4.0.4.tgz",
-      "integrity": "sha512-kUBE91efOWfIVBo8xzh/uZQ7p9ffYRtUbMRZBNFYwf0RK8koUMx6dGUfwylLOKmaT2cs4wSW96QoYUSXAyEtpg==",
-      "dependencies": {
-        "@types/unist": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/rehype-raw/node_modules/unist-util-stringify-position": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
-      "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
-      "dependencies": {
-        "@types/unist": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/rehype-raw/node_modules/unist-util-visit": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.2.tgz",
-      "integrity": "sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==",
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "unist-util-is": "^5.0.0",
-        "unist-util-visit-parents": "^5.1.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/rehype-raw/node_modules/unist-util-visit-parents": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
-      "integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "unist-util-is": "^5.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/rehype-raw/node_modules/vfile": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.7.tgz",
-      "integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "is-buffer": "^2.0.0",
-        "unist-util-stringify-position": "^3.0.0",
-        "vfile-message": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/rehype-raw/node_modules/vfile-location": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-4.1.0.tgz",
-      "integrity": "sha512-YF23YMyASIIJXpktBa4vIGLJ5Gs88UB/XePgqPmTa7cDA+JeO3yclbpheQYCHjVHBn/yePzrXuygIL+xbvRYHw==",
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "vfile": "^5.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/rehype-raw/node_modules/vfile-message": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.4.tgz",
-      "integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "unist-util-stringify-position": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/rehype-raw/node_modules/web-namespaces": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
-      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/rehype-raw/node_modules/zwitch": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
-      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/rehype-sanitize": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-5.0.1.tgz",
-      "integrity": "sha512-da/jIOjq8eYt/1r9GN6GwxIR3gde7OZ+WV8pheu1tL8K0D9KxM2AyMh+UEfke+FfdM3PvGHeYJU0Td5OWa7L5A==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-4.0.0.tgz",
+      "integrity": "sha512-ZCr/iQRr4JeqPjun5i9CHHILVY7i45VnLu1CkkibDrSyFQ7dTLSvw8OIQpHhS4RSh9h/9GidxFw1bRb0LOxIag==",
       "dependencies": {
-        "@types/hast": "^2.0.0",
-        "hast-util-sanitize": "^4.0.0",
-        "unified": "^10.0.0"
+        "hast-util-sanitize": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -26441,14 +25372,12 @@
       }
     },
     "node_modules/remark-gfm": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-3.0.1.tgz",
-      "integrity": "sha512-lEFDoi2PICJyNrACFOfDD3JlLkuSbOa5Wd8EPt06HUdptv8Gn0bxYTdbU/XXQ3swAPkEaGxxPN9cbnMHvVu1Ig==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-1.0.0.tgz",
+      "integrity": "sha512-KfexHJCiqvrdBZVbQ6RopMZGwaXz6wFJEfByIuEwGf0arvITHjiKKZ1dpXujjH9KZdm1//XJQwgfnJ3lmXaDPA==",
       "dependencies": {
-        "@types/mdast": "^3.0.0",
-        "mdast-util-gfm": "^2.0.0",
-        "micromark-extension-gfm": "^2.0.0",
-        "unified": "^10.0.0"
+        "mdast-util-gfm": "^0.1.0",
+        "micromark-extension-gfm": "^0.3.0"
       },
       "funding": {
         "type": "opencollective",
@@ -26538,25 +25467,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/remark-mdx/node_modules/bail": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
-      "integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==",
-      "dev": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/remark-mdx/node_modules/is-plain-obj": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/remark-mdx/node_modules/semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -26573,16 +25483,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/remark-mdx/node_modules/trough": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
-      "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
-      "dev": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/remark-mdx/node_modules/unified": {
@@ -26632,28 +25532,11 @@
       }
     },
     "node_modules/remark-rehype": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-10.1.0.tgz",
-      "integrity": "sha512-EFmR5zppdBp0WQeDVZ/b66CWJipB2q2VLNFMabzDSGR66Z2fQii83G5gTBbgGEnEEA0QRussvrFHxk1HWGJskw==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-8.1.0.tgz",
+      "integrity": "sha512-EbCu9kHgAxKmW1yEYjx3QafMyGY3q8noUbNUI5xyKbaFP89wbhDrKxyIQNukNYthzjNHZu6J7hwFg7hRm1svYA==",
       "dependencies": {
-        "@types/hast": "^2.0.0",
-        "@types/mdast": "^3.0.0",
-        "mdast-util-to-hast": "^12.1.0",
-        "unified": "^10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark-rehype/node_modules/mdast-util-definitions": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-5.1.2.tgz",
-      "integrity": "sha512-8SVPMuHqlPME/z3gqVwWY4zVXn8lqKv/pAhC57FuJ40ImXyBpmO5ukh98zB2v7Blql2FiHjHv9LVztSIqjY+MA==",
-      "dependencies": {
-        "@types/mdast": "^3.0.0",
-        "@types/unist": "^2.0.0",
-        "unist-util-visit": "^4.0.0"
+        "mdast-util-to-hast": "^10.2.0"
       },
       "funding": {
         "type": "opencollective",
@@ -26661,78 +25544,18 @@
       }
     },
     "node_modules/remark-rehype/node_modules/mdast-util-to-hast": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-12.3.0.tgz",
-      "integrity": "sha512-pits93r8PhnIoU4Vy9bjW39M2jJ6/tdHyja9rrot9uujkN7UTU9SDnE6WNJz/IGyQk3XHX6yNNtrBH6cQzm8Hw==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-10.2.0.tgz",
+      "integrity": "sha512-JoPBfJ3gBnHZ18icCwHR50orC9kNH81tiR1gs01D8Q5YpV6adHNO9nKNuFBCJQ941/32PT1a63UF/DitmS3amQ==",
       "dependencies": {
-        "@types/hast": "^2.0.0",
         "@types/mdast": "^3.0.0",
-        "mdast-util-definitions": "^5.0.0",
-        "micromark-util-sanitize-uri": "^1.1.0",
-        "trim-lines": "^3.0.0",
-        "unist-util-generated": "^2.0.0",
-        "unist-util-position": "^4.0.0",
-        "unist-util-visit": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark-rehype/node_modules/unist-util-generated": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-2.0.1.tgz",
-      "integrity": "sha512-qF72kLmPxAw0oN2fwpWIqbXAVyEqUzDHMsbtPvOudIlUzXYFIeQIuxXQCRCFh22B7cixvU0MG7m3MW8FTq/S+A==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark-rehype/node_modules/unist-util-is": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
-      "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
-      "dependencies": {
-        "@types/unist": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark-rehype/node_modules/unist-util-position": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-4.0.4.tgz",
-      "integrity": "sha512-kUBE91efOWfIVBo8xzh/uZQ7p9ffYRtUbMRZBNFYwf0RK8koUMx6dGUfwylLOKmaT2cs4wSW96QoYUSXAyEtpg==",
-      "dependencies": {
-        "@types/unist": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark-rehype/node_modules/unist-util-visit": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.2.tgz",
-      "integrity": "sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==",
-      "dependencies": {
         "@types/unist": "^2.0.0",
-        "unist-util-is": "^5.0.0",
-        "unist-util-visit-parents": "^5.1.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark-rehype/node_modules/unist-util-visit-parents": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
-      "integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "unist-util-is": "^5.0.0"
+        "mdast-util-definitions": "^4.0.0",
+        "mdurl": "^1.0.0",
+        "unist-builder": "^2.0.0",
+        "unist-util-generated": "^1.0.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -26885,7 +25708,6 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
-      "dev": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -27117,17 +25939,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
-    },
-    "node_modules/sade": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
-      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
-      "dependencies": {
-        "mri": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
@@ -28019,7 +26830,6 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz",
       "integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==",
-      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -28663,7 +27473,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.3.0.tgz",
       "integrity": "sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==",
-      "dev": true,
       "dependencies": {
         "inline-style-parser": "0.1.1"
       }
@@ -29351,15 +28160,6 @@
       "integrity": "sha512-h82ywcYhHK7veeelXrCScdH7HkWfbIT1D/CgYO+nmDarz3SGNssVBMws6jU16Ga60AJCRAvPV6w6RLuNerQqjg==",
       "dev": true
     },
-    "node_modules/trim-lines": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
-      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/trim-newlines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
@@ -29381,9 +28181,9 @@
       }
     },
     "node_modules/trough": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/trough/-/trough-2.1.0.tgz",
-      "integrity": "sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
+      "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -29833,57 +28633,16 @@
       }
     },
     "node_modules/unified": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
-      "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-9.2.2.tgz",
+      "integrity": "sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ==",
       "dependencies": {
-        "@types/unist": "^2.0.0",
-        "bail": "^2.0.0",
+        "bail": "^1.0.0",
         "extend": "^3.0.0",
         "is-buffer": "^2.0.0",
-        "is-plain-obj": "^4.0.0",
-        "trough": "^2.0.0",
-        "vfile": "^5.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unified/node_modules/unist-util-stringify-position": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
-      "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
-      "dependencies": {
-        "@types/unist": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unified/node_modules/vfile": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.7.tgz",
-      "integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "is-buffer": "^2.0.0",
-        "unist-util-stringify-position": "^3.0.0",
-        "vfile-message": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unified/node_modules/vfile-message": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.4.tgz",
-      "integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "unist-util-stringify-position": "^3.0.0"
+        "is-plain-obj": "^2.0.0",
+        "trough": "^1.0.0",
+        "vfile": "^4.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -29948,7 +28707,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-2.0.3.tgz",
       "integrity": "sha512-f98yt5pnlMWlzP539tPc4grGMsFaQQlP/vM396b00jngsiINumNmsY8rkXjfoi1c6QaM8nQ3vaGDuoKWbe/1Uw==",
-      "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
@@ -29958,7 +28716,6 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-1.1.6.tgz",
       "integrity": "sha512-cln2Mm1/CZzN5ttGK7vkoGw+RZ8VcUH6BtGbq98DDtRGquAAOXig1mrBQYelOwMXYS8rK+vZDyyojSjp7JX+Lg==",
-      "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
@@ -29968,7 +28725,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
       "integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==",
-      "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
@@ -29978,7 +28734,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-3.1.0.tgz",
       "integrity": "sha512-w+PkwCbYSFw8vpgWD0v7zRCl1FpY3fjDSQ3/N/wNd9Ffa4gPi8+4keqt99N3XW6F99t/mUzp2xAhNmfKWp95QA==",
-      "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
@@ -30014,7 +28769,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
       "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
-      "dev": true,
       "dependencies": {
         "@types/unist": "^2.0.2"
       },
@@ -30027,7 +28781,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.3.tgz",
       "integrity": "sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==",
-      "dev": true,
       "dependencies": {
         "@types/unist": "^2.0.0",
         "unist-util-is": "^4.0.0",
@@ -30042,7 +28795,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.1.1.tgz",
       "integrity": "sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==",
-      "dev": true,
       "dependencies": {
         "@types/unist": "^2.0.0",
         "unist-util-is": "^4.0.0"
@@ -30304,31 +29056,6 @@
       "integrity": "sha512-dsNgbLaTrd6l3MMxTtouOCFw4CBFc/3a+GgYA2YyrJvyQ1u6q4pcu3ktLoUZ/VN/Aw9WsauazbgsgdfVWgAKQg==",
       "dev": true
     },
-    "node_modules/uvu": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.6.tgz",
-      "integrity": "sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==",
-      "dependencies": {
-        "dequal": "^2.0.0",
-        "diff": "^5.0.0",
-        "kleur": "^4.0.3",
-        "sade": "^1.7.3"
-      },
-      "bin": {
-        "uvu": "bin.js"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/uvu/node_modules/kleur": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
-      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/v8-to-istanbul": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.0.1.tgz",
@@ -30366,7 +29093,6 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.2.1.tgz",
       "integrity": "sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==",
-      "dev": true,
       "dependencies": {
         "@types/unist": "^2.0.0",
         "is-buffer": "^2.0.0",
@@ -30382,7 +29108,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-3.2.0.tgz",
       "integrity": "sha512-aLEIZKv/oxuCDZ8lkJGhuhztf/BW4M+iHdCwglA/eWc+vtuRFJj8EtgceYFX4LRjOhCAAiNHsKGssC6onJ+jbA==",
-      "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
@@ -30392,7 +29117,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.4.tgz",
       "integrity": "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==",
-      "dev": true,
       "dependencies": {
         "@types/unist": "^2.0.0",
         "unist-util-stringify-position": "^2.0.0"
@@ -30816,7 +29540,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-1.1.4.tgz",
       "integrity": "sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==",
-      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -31619,7 +30342,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.4"
       }
@@ -31776,7 +30498,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-1.0.5.tgz",
       "integrity": "sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==",
-      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -35020,18 +33741,6 @@
             "@babel/helper-plugin-utils": "^7.10.4"
           }
         },
-        "bail": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
-          "integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==",
-          "dev": true
-        },
-        "is-plain-obj": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-          "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
-          "dev": true
-        },
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -35042,12 +33751,6 @@
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-          "dev": true
-        },
-        "trough": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
-          "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
           "dev": true
         },
         "unified": {
@@ -37260,14 +35963,6 @@
         "@babel/types": "^7.3.0"
       }
     },
-    "@types/debug": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
-      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
-      "requires": {
-        "@types/ms": "*"
-      }
-    },
     "@types/estree": {
       "version": "0.0.51",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
@@ -37456,11 +36151,6 @@
       "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
       "dev": true
     },
-    "@types/ms": {
-      "version": "0.7.31",
-      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
-      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
-    },
     "@types/node": {
       "version": "18.11.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
@@ -37498,8 +36188,7 @@
     "@types/parse5": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-5.0.3.tgz",
-      "integrity": "sha512-kUNnecmtkunAoQ3CnjmMkzNU/gtxG8guhi+Fk2U/kOpIKjIMKnXGp4IJCgQJrXSgMsWYimYG4TGjz/UzbGEBTw==",
-      "dev": true
+      "integrity": "sha512-kUNnecmtkunAoQ3CnjmMkzNU/gtxG8guhi+Fk2U/kOpIKjIMKnXGp4IJCgQJrXSgMsWYimYG4TGjz/UzbGEBTw=="
     },
     "@types/prettier": {
       "version": "2.7.1",
@@ -37516,7 +36205,8 @@
     "@types/prop-types": {
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
+      "dev": true
     },
     "@types/qs": {
       "version": "6.9.7",
@@ -39072,9 +37762,9 @@
       }
     },
     "bail": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
-      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
+      "integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ=="
     },
     "balanced-match": {
       "version": "1.0.2",
@@ -39718,8 +38408,7 @@
     "ccount": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.1.0.tgz",
-      "integrity": "sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==",
-      "dev": true
+      "integrity": "sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg=="
     },
     "chalk": {
       "version": "2.4.2",
@@ -39741,20 +38430,17 @@
     "character-entities": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
-      "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
-      "dev": true
+      "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw=="
     },
     "character-entities-legacy": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
-      "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
-      "dev": true
+      "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA=="
     },
     "character-reference-invalid": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
-      "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
-      "dev": true
+      "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg=="
     },
     "chokidar": {
       "version": "3.5.3",
@@ -40060,8 +38746,7 @@
     "comma-separated-tokens": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz",
-      "integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==",
-      "dev": true
+      "integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw=="
     },
     "commander": {
       "version": "6.2.1",
@@ -40877,21 +39562,6 @@
       "integrity": "sha512-ic1yEvwT6GuvaYwBLLY6/aFFgjZdySKTE8en/fkU3QICTmRtgtSlFn0u0BXN06InZwtfCelR7j8LRiDI/02iGA==",
       "dev": true
     },
-    "decode-named-character-reference": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.0.2.tgz",
-      "integrity": "sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==",
-      "requires": {
-        "character-entities": "^2.0.0"
-      },
-      "dependencies": {
-        "character-entities": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
-          "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="
-        }
-      }
-    },
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
@@ -41037,11 +39707,6 @@
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "dev": true
     },
-    "dequal": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="
-    },
     "des.js": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
@@ -41108,11 +39773,6 @@
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
       "dev": true
-    },
-    "diff": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
-      "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw=="
     },
     "diff-sequences": {
       "version": "29.2.0",
@@ -43757,7 +42417,6 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/hast-to-hyperscript/-/hast-to-hyperscript-9.0.1.tgz",
       "integrity": "sha512-zQgLKqF+O2F72S1aa4y2ivxzSlko3MAvxkwG8ehGmNiqd98BIN3JM1rAJPmplEyLmGLO2QZYJtIneOSZ2YbJuA==",
-      "dev": true,
       "requires": {
         "@types/unist": "^2.0.3",
         "comma-separated-tokens": "^1.0.0",
@@ -43772,7 +42431,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-6.0.1.tgz",
       "integrity": "sha512-jeJUWiN5pSxW12Rh01smtVkZgZr33wBokLzKLwinYOUfSzm1Nl/c3GUGebDyOKjdsRgMvoVbV0VpAcpjF4NrJA==",
-      "dev": true,
       "requires": {
         "@types/parse5": "^5.0.0",
         "hastscript": "^6.0.0",
@@ -43785,8 +42443,7 @@
     "hast-util-parse-selector": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.5.tgz",
-      "integrity": "sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ==",
-      "dev": true
+      "integrity": "sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ=="
     },
     "hast-util-raw": {
       "version": "6.0.1",
@@ -43807,18 +42464,17 @@
       }
     },
     "hast-util-sanitize": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-4.1.0.tgz",
-      "integrity": "sha512-Hd9tU0ltknMGRDv+d6Ro/4XKzBqQnP/EZrpiTbpFYfXv/uOhWeKc+2uajcbEvAEH98VZd7eII2PiXm13RihnLw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-3.0.2.tgz",
+      "integrity": "sha512-+2I0x2ZCAyiZOO/sb4yNLFmdwPBnyJ4PBkVTUMKMqBwYNA+lXSgOmoRXlJFazoyid9QPogRRKgKhVEodv181sA==",
       "requires": {
-        "@types/hast": "^2.0.0"
+        "xtend": "^4.0.0"
       }
     },
     "hast-util-to-parse5": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-6.0.0.tgz",
       "integrity": "sha512-Lu5m6Lgm/fWuz8eWnrKezHtVY83JeRGaNQ2kn9aJgqaxvVkFCZQBEhgodZUDUvoodgyROHDb3r5IxAEdl6suJQ==",
-      "dev": true,
       "requires": {
         "hast-to-hyperscript": "^9.0.0",
         "property-information": "^5.0.0",
@@ -43827,16 +42483,10 @@
         "zwitch": "^1.0.0"
       }
     },
-    "hast-util-whitespace": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-2.0.1.tgz",
-      "integrity": "sha512-nAxA0v8+vXSBDt3AnRUNjyRIQ0rD+ntpbAp4LnPkumc5M9yUbSMa4XDU9Q6etY4f1Wp4bNgvc1yjiZtsTTrSng=="
-    },
     "hastscript": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-6.0.0.tgz",
       "integrity": "sha512-nDM6bvd7lIqDUiYEiu5Sl/+6ReP0BMk/2f4U/Rooccxkj0P5nm+acM5PrGJ/t5I8qPGiqZSE6hVAwZEdZIvP4w==",
-      "dev": true,
       "requires": {
         "@types/hast": "^2.0.0",
         "comma-separated-tokens": "^1.0.0",
@@ -43930,8 +42580,7 @@
     "html-void-elements": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-1.0.5.tgz",
-      "integrity": "sha512-uE/TxKuyNIcx44cIWnjr/rfIATDH7ZaOMmstu0CwhFG1Dunhlp4OC6/NMbhiwoq5BpW0ubi303qnEk/PZj614w==",
-      "dev": true
+      "integrity": "sha512-uE/TxKuyNIcx44cIWnjr/rfIATDH7ZaOMmstu0CwhFG1Dunhlp4OC6/NMbhiwoq5BpW0ubi303qnEk/PZj614w=="
     },
     "html-webpack-plugin": {
       "version": "4.5.2",
@@ -44261,14 +42910,12 @@
     "is-alphabetical": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
-      "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
-      "dev": true
+      "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg=="
     },
     "is-alphanumerical": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
       "integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
-      "dev": true,
       "requires": {
         "is-alphabetical": "^1.0.0",
         "is-decimal": "^1.0.0"
@@ -44376,8 +43023,7 @@
     "is-decimal": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
-      "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
-      "dev": true
+      "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw=="
     },
     "is-descriptor": {
       "version": "1.0.2",
@@ -44452,8 +43098,7 @@
     "is-hexadecimal": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
-      "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
-      "dev": true
+      "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw=="
     },
     "is-map": {
       "version": "2.0.2",
@@ -44501,9 +43146,9 @@
       "dev": true
     },
     "is-plain-obj": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
-      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
     },
     "is-plain-object": {
       "version": "2.0.4",
@@ -48320,9 +46965,9 @@
       "dev": true
     },
     "longest-streak": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
-      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.4.tgz",
+      "integrity": "sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg=="
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -48463,9 +47108,12 @@
       "dev": true
     },
     "markdown-table": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.3.tgz",
-      "integrity": "sha512-Z1NL3Tb1M9wH4XESsCDEksWoKTdlUafKc4pt0GRwjUyXaCFZ+dc3g2erqB6zm3szA2IUSi7VnPI+o/9jnxh9hw=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
+      "integrity": "sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==",
+      "requires": {
+        "repeat-string": "^1.0.0"
+      }
     },
     "md5.js": {
       "version": "1.3.5",
@@ -48491,171 +47139,72 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-4.0.0.tgz",
       "integrity": "sha512-k8AJ6aNnUkB7IE+5azR9h81O5EQ/cTDXtWdMq9Kk5KcEW/8ritU5CeLg/9HhOC++nALHBlaogJ5jz0Ybk3kPMQ==",
-      "dev": true,
       "requires": {
         "unist-util-visit": "^2.0.0"
       }
     },
     "mdast-util-find-and-replace": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-2.2.2.tgz",
-      "integrity": "sha512-MTtdFRz/eMDHXzeK6W3dO7mXUlF82Gom4y0oOgvHhh/HXZAGvIQDUvQ0SuUx+j2tv44b8xTHOm8K/9OoRFnXKw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-1.1.1.tgz",
+      "integrity": "sha512-9cKl33Y21lyckGzpSmEQnIDjEfeeWelN5s1kUW1LwdB0Fkuq2u+4GdqcGEygYxJE8GVqCl0741bYXHgamfWAZA==",
       "requires": {
-        "@types/mdast": "^3.0.0",
-        "escape-string-regexp": "^5.0.0",
-        "unist-util-is": "^5.0.0",
-        "unist-util-visit-parents": "^5.0.0"
+        "escape-string-regexp": "^4.0.0",
+        "unist-util-is": "^4.0.0",
+        "unist-util-visit-parents": "^3.0.0"
       },
       "dependencies": {
         "escape-string-regexp": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-          "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="
-        },
-        "unist-util-is": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
-          "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
-          "requires": {
-            "@types/unist": "^2.0.0"
-          }
-        },
-        "unist-util-visit-parents": {
-          "version": "5.1.3",
-          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
-          "integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
-          "requires": {
-            "@types/unist": "^2.0.0",
-            "unist-util-is": "^5.0.0"
-          }
-        }
-      }
-    },
-    "mdast-util-from-markdown": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.3.0.tgz",
-      "integrity": "sha512-HN3W1gRIuN/ZW295c7zi7g9lVBllMgZE40RxCX37wrTPWXCWtpvOZdfnuK+1WNpvZje6XuJeI3Wnb4TJEUem+g==",
-      "requires": {
-        "@types/mdast": "^3.0.0",
-        "@types/unist": "^2.0.0",
-        "decode-named-character-reference": "^1.0.0",
-        "mdast-util-to-string": "^3.1.0",
-        "micromark": "^3.0.0",
-        "micromark-util-decode-numeric-character-reference": "^1.0.0",
-        "micromark-util-decode-string": "^1.0.0",
-        "micromark-util-normalize-identifier": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.0",
-        "unist-util-stringify-position": "^3.0.0",
-        "uvu": "^0.5.0"
-      },
-      "dependencies": {
-        "mdast-util-to-string": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.1.1.tgz",
-          "integrity": "sha512-tGvhT94e+cVnQt8JWE9/b3cUQZWS732TJxXHktvP+BYo62PpYD53Ls/6cC60rW21dW+txxiM4zMdc6abASvZKA==",
-          "requires": {
-            "@types/mdast": "^3.0.0"
-          }
-        },
-        "unist-util-stringify-position": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
-          "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
-          "requires": {
-            "@types/unist": "^2.0.0"
-          }
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
         }
       }
     },
     "mdast-util-gfm": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-2.0.2.tgz",
-      "integrity": "sha512-qvZ608nBppZ4icQlhQQIAdc6S3Ffj9RGmzwUKUWuEICFnd1LVkN3EktF7ZHAgfcEdvZB5owU9tQgt99e2TlLjg==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-0.1.2.tgz",
+      "integrity": "sha512-NNkhDx/qYcuOWB7xHUGWZYVXvjPFFd6afg6/e2g+SV4r9q5XUcCbV4Wfa3DLYIiD+xAEZc6K4MGaE/m0KDcPwQ==",
       "requires": {
-        "mdast-util-from-markdown": "^1.0.0",
-        "mdast-util-gfm-autolink-literal": "^1.0.0",
-        "mdast-util-gfm-footnote": "^1.0.0",
-        "mdast-util-gfm-strikethrough": "^1.0.0",
-        "mdast-util-gfm-table": "^1.0.0",
-        "mdast-util-gfm-task-list-item": "^1.0.0",
-        "mdast-util-to-markdown": "^1.0.0"
+        "mdast-util-gfm-autolink-literal": "^0.1.0",
+        "mdast-util-gfm-strikethrough": "^0.2.0",
+        "mdast-util-gfm-table": "^0.1.0",
+        "mdast-util-gfm-task-list-item": "^0.1.0",
+        "mdast-util-to-markdown": "^0.6.1"
       }
     },
     "mdast-util-gfm-autolink-literal": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-1.0.3.tgz",
-      "integrity": "sha512-My8KJ57FYEy2W2LyNom4n3E7hKTuQk/0SES0u16tjA9Z3oFkF4RrC/hPAPgjlSpezsOvI8ObcXcElo92wn5IGA==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-0.1.3.tgz",
+      "integrity": "sha512-GjmLjWrXg1wqMIO9+ZsRik/s7PLwTaeCHVB7vRxUwLntZc8mzmTsLVr6HW1yLokcnhfURsn5zmSVdi3/xWWu1A==",
       "requires": {
-        "@types/mdast": "^3.0.0",
-        "ccount": "^2.0.0",
-        "mdast-util-find-and-replace": "^2.0.0",
-        "micromark-util-character": "^1.0.0"
-      },
-      "dependencies": {
-        "ccount": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
-          "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="
-        }
-      }
-    },
-    "mdast-util-gfm-footnote": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-1.0.2.tgz",
-      "integrity": "sha512-56D19KOGbE00uKVj3sgIykpwKL179QsVFwx/DCW0u/0+URsryacI4MAdNJl0dh+u2PSsD9FtxPFbHCzJ78qJFQ==",
-      "requires": {
-        "@types/mdast": "^3.0.0",
-        "mdast-util-to-markdown": "^1.3.0",
-        "micromark-util-normalize-identifier": "^1.0.0"
+        "ccount": "^1.0.0",
+        "mdast-util-find-and-replace": "^1.1.0",
+        "micromark": "^2.11.3"
       }
     },
     "mdast-util-gfm-strikethrough": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-1.0.3.tgz",
-      "integrity": "sha512-DAPhYzTYrRcXdMjUtUjKvW9z/FNAMTdU0ORyMcbmkwYNbKocDpdk+PX1L1dQgOID/+vVs1uBQ7ElrBQfZ0cuiQ==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-0.2.3.tgz",
+      "integrity": "sha512-5OQLXpt6qdbttcDG/UxYY7Yjj3e8P7X16LzvpX8pIQPYJ/C2Z1qFGMmcw+1PZMUM3Z8wt8NRfYTvCni93mgsgA==",
       "requires": {
-        "@types/mdast": "^3.0.0",
-        "mdast-util-to-markdown": "^1.3.0"
+        "mdast-util-to-markdown": "^0.6.0"
       }
     },
     "mdast-util-gfm-table": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-1.0.7.tgz",
-      "integrity": "sha512-jjcpmNnQvrmN5Vx7y7lEc2iIOEytYv7rTvu+MeyAsSHTASGCCRA79Igg2uKssgOs1i1po8s3plW0sTu1wkkLGg==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-0.1.6.tgz",
+      "integrity": "sha512-j4yDxQ66AJSBwGkbpFEp9uG/LS1tZV3P33fN1gkyRB2LoRL+RR3f76m0HPHaby6F4Z5xr9Fv1URmATlRRUIpRQ==",
       "requires": {
-        "@types/mdast": "^3.0.0",
-        "markdown-table": "^3.0.0",
-        "mdast-util-from-markdown": "^1.0.0",
-        "mdast-util-to-markdown": "^1.3.0"
+        "markdown-table": "^2.0.0",
+        "mdast-util-to-markdown": "~0.6.0"
       }
     },
     "mdast-util-gfm-task-list-item": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-1.0.2.tgz",
-      "integrity": "sha512-PFTA1gzfp1B1UaiJVyhJZA1rm0+Tzn690frc/L8vNX1Jop4STZgOE6bxUhnzdVSB+vm2GU1tIsuQcA9bxTQpMQ==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-0.1.6.tgz",
+      "integrity": "sha512-/d51FFIfPsSmCIRNp7E6pozM9z1GYPIkSy1urQ8s/o4TC22BZ7DqfHFWiqBD23bc7J3vV1Fc9O4QIHBlfuit8A==",
       "requires": {
-        "@types/mdast": "^3.0.0",
-        "mdast-util-to-markdown": "^1.3.0"
-      }
-    },
-    "mdast-util-phrasing": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-3.0.1.tgz",
-      "integrity": "sha512-WmI1gTXUBJo4/ZmSk79Wcb2HcjPJBzM1nlI/OUWA8yk2X9ik3ffNbBGsU+09BFmXaL1IBb9fiuvq6/KMiNycSg==",
-      "requires": {
-        "@types/mdast": "^3.0.0",
-        "unist-util-is": "^5.0.0"
-      },
-      "dependencies": {
-        "unist-util-is": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
-          "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
-          "requires": {
-            "@types/unist": "^2.0.0"
-          }
-        }
+        "mdast-util-to-markdown": "~0.6.0"
       }
     },
     "mdast-util-to-hast": {
@@ -48675,59 +47224,22 @@
       }
     },
     "mdast-util-to-markdown": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-1.5.0.tgz",
-      "integrity": "sha512-bbv7TPv/WC49thZPg3jXuqzuvI45IL2EVAr/KxF0BSdHsU0ceFHOmwQn6evxAh1GaoK/6GQ1wp4R4oW2+LFL/A==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-0.6.5.tgz",
+      "integrity": "sha512-XeV9sDE7ZlOQvs45C9UKMtfTcctcaj/pGwH8YLbMHoMOXNNCn2LsqVQOqrF1+/NU8lKDAqozme9SCXWyo9oAcQ==",
       "requires": {
-        "@types/mdast": "^3.0.0",
         "@types/unist": "^2.0.0",
-        "longest-streak": "^3.0.0",
-        "mdast-util-phrasing": "^3.0.0",
-        "mdast-util-to-string": "^3.0.0",
-        "micromark-util-decode-string": "^1.0.0",
-        "unist-util-visit": "^4.0.0",
-        "zwitch": "^2.0.0"
+        "longest-streak": "^2.0.0",
+        "mdast-util-to-string": "^2.0.0",
+        "parse-entities": "^2.0.0",
+        "repeat-string": "^1.0.0",
+        "zwitch": "^1.0.0"
       },
       "dependencies": {
         "mdast-util-to-string": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.1.1.tgz",
-          "integrity": "sha512-tGvhT94e+cVnQt8JWE9/b3cUQZWS732TJxXHktvP+BYo62PpYD53Ls/6cC60rW21dW+txxiM4zMdc6abASvZKA==",
-          "requires": {
-            "@types/mdast": "^3.0.0"
-          }
-        },
-        "unist-util-is": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
-          "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
-          "requires": {
-            "@types/unist": "^2.0.0"
-          }
-        },
-        "unist-util-visit": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.2.tgz",
-          "integrity": "sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==",
-          "requires": {
-            "@types/unist": "^2.0.0",
-            "unist-util-is": "^5.0.0",
-            "unist-util-visit-parents": "^5.1.1"
-          }
-        },
-        "unist-util-visit-parents": {
-          "version": "5.1.3",
-          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
-          "integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
-          "requires": {
-            "@types/unist": "^2.0.0",
-            "unist-util-is": "^5.0.0"
-          }
-        },
-        "zwitch": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
-          "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz",
+          "integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w=="
         }
       }
     },
@@ -48740,8 +47252,7 @@
     "mdurl": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
-      "dev": true
+      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g=="
     },
     "media-typer": {
       "version": "0.3.0",
@@ -48924,303 +47435,63 @@
       "dev": true
     },
     "micromark": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/micromark/-/micromark-3.1.0.tgz",
-      "integrity": "sha512-6Mj0yHLdUZjHnOPgr5xfWIMqMWS12zDN6iws9SLuSz76W8jTtAv24MN4/CL7gJrl5vtxGInkkqDv/JIoRsQOvA==",
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.4.tgz",
+      "integrity": "sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==",
       "requires": {
-        "@types/debug": "^4.0.0",
         "debug": "^4.0.0",
-        "decode-named-character-reference": "^1.0.0",
-        "micromark-core-commonmark": "^1.0.1",
-        "micromark-factory-space": "^1.0.0",
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-chunked": "^1.0.0",
-        "micromark-util-combine-extensions": "^1.0.0",
-        "micromark-util-decode-numeric-character-reference": "^1.0.0",
-        "micromark-util-encode": "^1.0.0",
-        "micromark-util-normalize-identifier": "^1.0.0",
-        "micromark-util-resolve-all": "^1.0.0",
-        "micromark-util-sanitize-uri": "^1.0.0",
-        "micromark-util-subtokenize": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.1",
-        "uvu": "^0.5.0"
-      }
-    },
-    "micromark-core-commonmark": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-1.0.6.tgz",
-      "integrity": "sha512-K+PkJTxqjFfSNkfAhp4GB+cZPfQd6dxtTXnf+RjZOV7T4EEXnvgzOcnp+eSTmpGk9d1S9sL6/lqrgSNn/s0HZA==",
-      "requires": {
-        "decode-named-character-reference": "^1.0.0",
-        "micromark-factory-destination": "^1.0.0",
-        "micromark-factory-label": "^1.0.0",
-        "micromark-factory-space": "^1.0.0",
-        "micromark-factory-title": "^1.0.0",
-        "micromark-factory-whitespace": "^1.0.0",
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-chunked": "^1.0.0",
-        "micromark-util-classify-character": "^1.0.0",
-        "micromark-util-html-tag-name": "^1.0.0",
-        "micromark-util-normalize-identifier": "^1.0.0",
-        "micromark-util-resolve-all": "^1.0.0",
-        "micromark-util-subtokenize": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.1",
-        "uvu": "^0.5.0"
+        "parse-entities": "^2.0.0"
       }
     },
     "micromark-extension-gfm": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-2.0.1.tgz",
-      "integrity": "sha512-p2sGjajLa0iYiGQdT0oelahRYtMWvLjy8J9LOCxzIQsllMCGLbsLW+Nc+N4vi02jcRJvedVJ68cjelKIO6bpDA==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-0.3.3.tgz",
+      "integrity": "sha512-oVN4zv5/tAIA+l3GbMi7lWeYpJ14oQyJ3uEim20ktYFAcfX1x3LNlFGGlmrZHt7u9YlKExmyJdDGaTt6cMSR/A==",
       "requires": {
-        "micromark-extension-gfm-autolink-literal": "^1.0.0",
-        "micromark-extension-gfm-footnote": "^1.0.0",
-        "micromark-extension-gfm-strikethrough": "^1.0.0",
-        "micromark-extension-gfm-table": "^1.0.0",
-        "micromark-extension-gfm-tagfilter": "^1.0.0",
-        "micromark-extension-gfm-task-list-item": "^1.0.0",
-        "micromark-util-combine-extensions": "^1.0.0",
-        "micromark-util-types": "^1.0.0"
+        "micromark": "~2.11.0",
+        "micromark-extension-gfm-autolink-literal": "~0.5.0",
+        "micromark-extension-gfm-strikethrough": "~0.6.5",
+        "micromark-extension-gfm-table": "~0.4.0",
+        "micromark-extension-gfm-tagfilter": "~0.3.0",
+        "micromark-extension-gfm-task-list-item": "~0.3.0"
       }
     },
     "micromark-extension-gfm-autolink-literal": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-1.0.3.tgz",
-      "integrity": "sha512-i3dmvU0htawfWED8aHMMAzAVp/F0Z+0bPh3YrbTPPL1v4YAlCZpy5rBO5p0LPYiZo0zFVkoYh7vDU7yQSiCMjg==",
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-0.5.7.tgz",
+      "integrity": "sha512-ePiDGH0/lhcngCe8FtH4ARFoxKTUelMp4L7Gg2pujYD5CSMb9PbblnyL+AAMud/SNMyusbS2XDSiPIRcQoNFAw==",
       "requires": {
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-sanitize-uri": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.0",
-        "uvu": "^0.5.0"
-      }
-    },
-    "micromark-extension-gfm-footnote": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-1.0.4.tgz",
-      "integrity": "sha512-E/fmPmDqLiMUP8mLJ8NbJWJ4bTw6tS+FEQS8CcuDtZpILuOb2kjLqPEeAePF1djXROHXChM/wPJw0iS4kHCcIg==",
-      "requires": {
-        "micromark-core-commonmark": "^1.0.0",
-        "micromark-factory-space": "^1.0.0",
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-normalize-identifier": "^1.0.0",
-        "micromark-util-sanitize-uri": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.0",
-        "uvu": "^0.5.0"
+        "micromark": "~2.11.3"
       }
     },
     "micromark-extension-gfm-strikethrough": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-1.0.4.tgz",
-      "integrity": "sha512-/vjHU/lalmjZCT5xt7CcHVJGq8sYRm80z24qAKXzaHzem/xsDYb2yLL+NNVbYvmpLx3O7SYPuGL5pzusL9CLIQ==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-0.6.5.tgz",
+      "integrity": "sha512-PpOKlgokpQRwUesRwWEp+fHjGGkZEejj83k9gU5iXCbDG+XBA92BqnRKYJdfqfkrRcZRgGuPuXb7DaK/DmxOhw==",
       "requires": {
-        "micromark-util-chunked": "^1.0.0",
-        "micromark-util-classify-character": "^1.0.0",
-        "micromark-util-resolve-all": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.0",
-        "uvu": "^0.5.0"
+        "micromark": "~2.11.0"
       }
     },
     "micromark-extension-gfm-table": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-1.0.5.tgz",
-      "integrity": "sha512-xAZ8J1X9W9K3JTJTUL7G6wSKhp2ZYHrFk5qJgY/4B33scJzE2kpfRL6oiw/veJTbt7jiM/1rngLlOKPWr1G+vg==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-0.4.3.tgz",
+      "integrity": "sha512-hVGvESPq0fk6ALWtomcwmgLvH8ZSVpcPjzi0AjPclB9FsVRgMtGZkUcpE0zgjOCFAznKepF4z3hX8z6e3HODdA==",
       "requires": {
-        "micromark-factory-space": "^1.0.0",
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.0",
-        "uvu": "^0.5.0"
+        "micromark": "~2.11.0"
       }
     },
     "micromark-extension-gfm-tagfilter": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-1.0.1.tgz",
-      "integrity": "sha512-Ty6psLAcAjboRa/UKUbbUcwjVAv5plxmpUTy2XC/3nJFL37eHej8jrHrRzkqcpipJliuBH30DTs7+3wqNcQUVA==",
-      "requires": {
-        "micromark-util-types": "^1.0.0"
-      }
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-0.3.0.tgz",
+      "integrity": "sha512-9GU0xBatryXifL//FJH+tAZ6i240xQuFrSL7mYi8f4oZSbc+NvXjkrHemeYP0+L4ZUT+Ptz3b95zhUZnMtoi/Q=="
     },
     "micromark-extension-gfm-task-list-item": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-1.0.3.tgz",
-      "integrity": "sha512-PpysK2S1Q/5VXi72IIapbi/jliaiOFzv7THH4amwXeYXLq3l1uo8/2Be0Ac1rEwK20MQEsGH2ltAZLNY2KI/0Q==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-0.3.3.tgz",
+      "integrity": "sha512-0zvM5iSLKrc/NQl84pZSjGo66aTGd57C1idmlWmE87lkMcXrTxg1uXa/nXomxJytoje9trP0NDLvw4bZ/Z/XCQ==",
       "requires": {
-        "micromark-factory-space": "^1.0.0",
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.0",
-        "uvu": "^0.5.0"
+        "micromark": "~2.11.0"
       }
-    },
-    "micromark-factory-destination": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-1.0.0.tgz",
-      "integrity": "sha512-eUBA7Rs1/xtTVun9TmV3gjfPz2wEwgK5R5xcbIM5ZYAtvGF6JkyaDsj0agx8urXnO31tEO6Ug83iVH3tdedLnw==",
-      "requires": {
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.0"
-      }
-    },
-    "micromark-factory-label": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-1.0.2.tgz",
-      "integrity": "sha512-CTIwxlOnU7dEshXDQ+dsr2n+yxpP0+fn271pu0bwDIS8uqfFcumXpj5mLn3hSC8iw2MUr6Gx8EcKng1dD7i6hg==",
-      "requires": {
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.0",
-        "uvu": "^0.5.0"
-      }
-    },
-    "micromark-factory-space": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-1.0.0.tgz",
-      "integrity": "sha512-qUmqs4kj9a5yBnk3JMLyjtWYN6Mzfcx8uJfi5XAveBniDevmZasdGBba5b4QsvRcAkmvGo5ACmSUmyGiKTLZew==",
-      "requires": {
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-types": "^1.0.0"
-      }
-    },
-    "micromark-factory-title": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-1.0.2.tgz",
-      "integrity": "sha512-zily+Nr4yFqgMGRKLpTVsNl5L4PMu485fGFDOQJQBl2NFpjGte1e86zC0da93wf97jrc4+2G2GQudFMHn3IX+A==",
-      "requires": {
-        "micromark-factory-space": "^1.0.0",
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.0",
-        "uvu": "^0.5.0"
-      }
-    },
-    "micromark-factory-whitespace": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-1.0.0.tgz",
-      "integrity": "sha512-Qx7uEyahU1lt1RnsECBiuEbfr9INjQTGa6Err+gF3g0Tx4YEviPbqqGKNv/NrBaE7dVHdn1bVZKM/n5I/Bak7A==",
-      "requires": {
-        "micromark-factory-space": "^1.0.0",
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.0"
-      }
-    },
-    "micromark-util-character": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-1.1.0.tgz",
-      "integrity": "sha512-agJ5B3unGNJ9rJvADMJ5ZiYjBRyDpzKAOk01Kpi1TKhlT1APx3XZk6eN7RtSz1erbWHC2L8T3xLZ81wdtGRZzg==",
-      "requires": {
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.0"
-      }
-    },
-    "micromark-util-chunked": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-1.0.0.tgz",
-      "integrity": "sha512-5e8xTis5tEZKgesfbQMKRCyzvffRRUX+lK/y+DvsMFdabAicPkkZV6gO+FEWi9RfuKKoxxPwNL+dFF0SMImc1g==",
-      "requires": {
-        "micromark-util-symbol": "^1.0.0"
-      }
-    },
-    "micromark-util-classify-character": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-1.0.0.tgz",
-      "integrity": "sha512-F8oW2KKrQRb3vS5ud5HIqBVkCqQi224Nm55o5wYLzY/9PwHGXC01tr3d7+TqHHz6zrKQ72Okwtvm/xQm6OVNZA==",
-      "requires": {
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.0"
-      }
-    },
-    "micromark-util-combine-extensions": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-1.0.0.tgz",
-      "integrity": "sha512-J8H058vFBdo/6+AsjHp2NF7AJ02SZtWaVUjsayNFeAiydTxUwViQPxN0Hf8dp4FmCQi0UUFovFsEyRSUmFH3MA==",
-      "requires": {
-        "micromark-util-chunked": "^1.0.0",
-        "micromark-util-types": "^1.0.0"
-      }
-    },
-    "micromark-util-decode-numeric-character-reference": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-1.0.0.tgz",
-      "integrity": "sha512-OzO9AI5VUtrTD7KSdagf4MWgHMtET17Ua1fIpXTpuhclCqD8egFWo85GxSGvxgkGS74bEahvtM0WP0HjvV0e4w==",
-      "requires": {
-        "micromark-util-symbol": "^1.0.0"
-      }
-    },
-    "micromark-util-decode-string": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-1.0.2.tgz",
-      "integrity": "sha512-DLT5Ho02qr6QWVNYbRZ3RYOSSWWFuH3tJexd3dgN1odEuPNxCngTCXJum7+ViRAd9BbdxCvMToPOD/IvVhzG6Q==",
-      "requires": {
-        "decode-named-character-reference": "^1.0.0",
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-decode-numeric-character-reference": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0"
-      }
-    },
-    "micromark-util-encode": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-1.0.1.tgz",
-      "integrity": "sha512-U2s5YdnAYexjKDel31SVMPbfi+eF8y1U4pfiRW/Y8EFVCy/vgxk/2wWTxzcqE71LHtCuCzlBDRU2a5CQ5j+mQA=="
-    },
-    "micromark-util-html-tag-name": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-1.1.0.tgz",
-      "integrity": "sha512-BKlClMmYROy9UiV03SwNmckkjn8QHVaWkqoAqzivabvdGcwNGMMMH/5szAnywmsTBUzDsU57/mFi0sp4BQO6dA=="
-    },
-    "micromark-util-normalize-identifier": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-1.0.0.tgz",
-      "integrity": "sha512-yg+zrL14bBTFrQ7n35CmByWUTFsgst5JhA4gJYoty4Dqzj4Z4Fr/DHekSS5aLfH9bdlfnSvKAWsAgJhIbogyBg==",
-      "requires": {
-        "micromark-util-symbol": "^1.0.0"
-      }
-    },
-    "micromark-util-resolve-all": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-1.0.0.tgz",
-      "integrity": "sha512-CB/AGk98u50k42kvgaMM94wzBqozSzDDaonKU7P7jwQIuH2RU0TeBqGYJz2WY1UdihhjweivStrJ2JdkdEmcfw==",
-      "requires": {
-        "micromark-util-types": "^1.0.0"
-      }
-    },
-    "micromark-util-sanitize-uri": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-1.1.0.tgz",
-      "integrity": "sha512-RoxtuSCX6sUNtxhbmsEFQfWzs8VN7cTctmBPvYivo98xb/kDEoTCtJQX5wyzIYEmk/lvNFTat4hL8oW0KndFpg==",
-      "requires": {
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-encode": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0"
-      }
-    },
-    "micromark-util-subtokenize": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-1.0.2.tgz",
-      "integrity": "sha512-d90uqCnXp/cy4G881Ub4psE57Sf8YD0pim9QdjCRNjfas2M1u6Lbt+XZK9gnHL2XFhnozZiEdCa9CNfXSfQ6xA==",
-      "requires": {
-        "micromark-util-chunked": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.0",
-        "uvu": "^0.5.0"
-      }
-    },
-    "micromark-util-symbol": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-1.0.1.tgz",
-      "integrity": "sha512-oKDEMK2u5qqAptasDAwWDXq0tG9AssVwAx3E9bBF3t/shRIGsWIRG+cGafs2p/SnDSOecnt6hZPCE2o6lHfFmQ=="
-    },
-    "micromark-util-types": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-1.0.2.tgz",
-      "integrity": "sha512-DCfg/T8fcrhrRKTPjRrw/5LLvdGV7BHySf/1LOZx7TzWZdYRjogNtyNq885z3nNallwr3QUKARjqvHqX1/7t+w=="
     },
     "micromatch": {
       "version": "4.0.5",
@@ -49431,11 +47702,6 @@
           }
         }
       }
-    },
-    "mri": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
-      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="
     },
     "ms": {
       "version": "2.1.2",
@@ -50352,7 +48618,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
       "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
-      "dev": true,
       "requires": {
         "character-entities": "^1.0.0",
         "character-entities-legacy": "^1.0.0",
@@ -50862,7 +49127,6 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.6.0.tgz",
       "integrity": "sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==",
-      "dev": true,
       "requires": {
         "xtend": "^4.0.0"
       }
@@ -51147,122 +49411,51 @@
     "react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
     "react-markdown": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-8.0.5.tgz",
-      "integrity": "sha512-jGJolWWmOWAvzf+xMdB9zwStViODyyFQhNB/bwCerbBKmrTmgmA599CGiOlP58OId1IMoIRsA8UdI1Lod4zb5A==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-6.0.3.tgz",
+      "integrity": "sha512-kQbpWiMoBHnj9myLlmZG9T1JdoT/OEyHK7hqM6CqFT14MAkgWiWBUYijLyBmxbntaN6dCDicPcUhWhci1QYodg==",
       "requires": {
         "@types/hast": "^2.0.0",
-        "@types/prop-types": "^15.0.0",
-        "@types/unist": "^2.0.0",
-        "comma-separated-tokens": "^2.0.0",
-        "hast-util-whitespace": "^2.0.0",
-        "prop-types": "^15.0.0",
-        "property-information": "^6.0.0",
-        "react-is": "^18.0.0",
-        "remark-parse": "^10.0.0",
-        "remark-rehype": "^10.0.0",
-        "space-separated-tokens": "^2.0.0",
-        "style-to-object": "^0.4.0",
-        "unified": "^10.0.0",
-        "unist-util-visit": "^4.0.0",
-        "vfile": "^5.0.0"
+        "@types/unist": "^2.0.3",
+        "comma-separated-tokens": "^1.0.0",
+        "prop-types": "^15.7.2",
+        "property-information": "^5.3.0",
+        "react-is": "^17.0.0",
+        "remark-parse": "^9.0.0",
+        "remark-rehype": "^8.0.0",
+        "space-separated-tokens": "^1.1.0",
+        "style-to-object": "^0.3.0",
+        "unified": "^9.0.0",
+        "unist-util-visit": "^2.0.0",
+        "vfile": "^4.0.0"
       },
       "dependencies": {
-        "comma-separated-tokens": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
-          "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="
-        },
-        "property-information": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.2.0.tgz",
-          "integrity": "sha512-kma4U7AFCTwpqq5twzC1YVIDXSqg6qQK6JN0smOw8fgRy1OkMi0CYSzFmsy6dnqSenamAtj0CyXMUJ1Mf6oROg=="
-        },
-        "react-is": {
-          "version": "18.2.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
-        },
-        "remark-parse": {
-          "version": "10.0.1",
-          "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-10.0.1.tgz",
-          "integrity": "sha512-1fUyHr2jLsVOkhbvPRBJ5zTKZZyD6yZzYaWCS6BPBdQ8vEMBCH+9zNCDA6tET/zHCi/jLqjCWtlJZUPk+DbnFw==",
+        "mdast-util-from-markdown": {
+          "version": "0.8.5",
+          "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz",
+          "integrity": "sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==",
           "requires": {
             "@types/mdast": "^3.0.0",
-            "mdast-util-from-markdown": "^1.0.0",
-            "unified": "^10.0.0"
+            "mdast-util-to-string": "^2.0.0",
+            "micromark": "~2.11.0",
+            "parse-entities": "^2.0.0",
+            "unist-util-stringify-position": "^2.0.0"
           }
         },
-        "space-separated-tokens": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
-          "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="
+        "mdast-util-to-string": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz",
+          "integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w=="
         },
-        "style-to-object": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.4.1.tgz",
-          "integrity": "sha512-HFpbb5gr2ypci7Qw+IOhnP2zOU7e77b+rzM+wTzXzfi1PrtBCX0E7Pk4wL4iTLnhzZ+JgEGAhX81ebTg/aYjQw==",
+        "remark-parse": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-9.0.0.tgz",
+          "integrity": "sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==",
           "requires": {
-            "inline-style-parser": "0.1.1"
-          }
-        },
-        "unist-util-is": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
-          "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
-          "requires": {
-            "@types/unist": "^2.0.0"
-          }
-        },
-        "unist-util-stringify-position": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
-          "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
-          "requires": {
-            "@types/unist": "^2.0.0"
-          }
-        },
-        "unist-util-visit": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.2.tgz",
-          "integrity": "sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==",
-          "requires": {
-            "@types/unist": "^2.0.0",
-            "unist-util-is": "^5.0.0",
-            "unist-util-visit-parents": "^5.1.1"
-          }
-        },
-        "unist-util-visit-parents": {
-          "version": "5.1.3",
-          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
-          "integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
-          "requires": {
-            "@types/unist": "^2.0.0",
-            "unist-util-is": "^5.0.0"
-          }
-        },
-        "vfile": {
-          "version": "5.3.7",
-          "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.7.tgz",
-          "integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
-          "requires": {
-            "@types/unist": "^2.0.0",
-            "is-buffer": "^2.0.0",
-            "unist-util-stringify-position": "^3.0.0",
-            "vfile-message": "^3.0.0"
-          }
-        },
-        "vfile-message": {
-          "version": "3.1.4",
-          "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.4.tgz",
-          "integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
-          "requires": {
-            "@types/unist": "^2.0.0",
-            "unist-util-stringify-position": "^3.0.0"
+            "mdast-util-from-markdown": "^0.8.0"
           }
         }
       }
@@ -51552,197 +49745,39 @@
       }
     },
     "rehype-raw": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-6.1.1.tgz",
-      "integrity": "sha512-d6AKtisSRtDRX4aSPsJGTfnzrX2ZkHQLE5kiUuGOeEoLpbEulFF4hj0mLPbsa+7vmguDKOVVEQdHKDSwoaIDsQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-5.1.0.tgz",
+      "integrity": "sha512-MDvHAb/5mUnif2R+0IPCYJU8WjHa9UzGtM/F4AVy5GixPlDZ1z3HacYy4xojDU+uBa+0X/3PIfyQI26/2ljJNA==",
       "requires": {
-        "@types/hast": "^2.0.0",
-        "hast-util-raw": "^7.2.0",
-        "unified": "^10.0.0"
+        "hast-util-raw": "^6.1.0"
       },
       "dependencies": {
-        "@types/parse5": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-6.0.3.tgz",
-          "integrity": "sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g=="
-        },
-        "comma-separated-tokens": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
-          "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="
-        },
-        "hast-util-from-parse5": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-7.1.2.tgz",
-          "integrity": "sha512-Nz7FfPBuljzsN3tCQ4kCBKqdNhQE2l0Tn+X1ubgKBPRoiDIu1mL08Cfw4k7q71+Duyaw7DXDN+VTAp4Vh3oCOw==",
-          "requires": {
-            "@types/hast": "^2.0.0",
-            "@types/unist": "^2.0.0",
-            "hastscript": "^7.0.0",
-            "property-information": "^6.0.0",
-            "vfile": "^5.0.0",
-            "vfile-location": "^4.0.0",
-            "web-namespaces": "^2.0.0"
-          }
-        },
-        "hast-util-parse-selector": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-3.1.1.tgz",
-          "integrity": "sha512-jdlwBjEexy1oGz0aJ2f4GKMaVKkA9jwjr4MjAAI22E5fM/TXVZHuS5OpONtdeIkRKqAaryQ2E9xNQxijoThSZA==",
-          "requires": {
-            "@types/hast": "^2.0.0"
-          }
-        },
         "hast-util-raw": {
-          "version": "7.2.3",
-          "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-7.2.3.tgz",
-          "integrity": "sha512-RujVQfVsOrxzPOPSzZFiwofMArbQke6DJjnFfceiEbFh7S05CbPt0cYN+A5YeD3pso0JQk6O1aHBnx9+Pm2uqg==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-6.1.0.tgz",
+          "integrity": "sha512-5FoZLDHBpka20OlZZ4I/+RBw5piVQ8iI1doEvffQhx5CbCyTtP8UCq8Tw6NmTAMtXgsQxmhW7Ly8OdFre5/YMQ==",
           "requires": {
             "@types/hast": "^2.0.0",
-            "@types/parse5": "^6.0.0",
-            "hast-util-from-parse5": "^7.0.0",
-            "hast-util-to-parse5": "^7.0.0",
-            "html-void-elements": "^2.0.0",
+            "hast-util-from-parse5": "^6.0.0",
+            "hast-util-to-parse5": "^6.0.0",
+            "html-void-elements": "^1.0.0",
             "parse5": "^6.0.0",
-            "unist-util-position": "^4.0.0",
-            "unist-util-visit": "^4.0.0",
-            "vfile": "^5.0.0",
-            "web-namespaces": "^2.0.0",
-            "zwitch": "^2.0.0"
+            "unist-util-position": "^3.0.0",
+            "unist-util-visit": "^2.0.0",
+            "vfile": "^4.0.0",
+            "web-namespaces": "^1.0.0",
+            "xtend": "^4.0.0",
+            "zwitch": "^1.0.0"
           }
-        },
-        "hast-util-to-parse5": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-7.1.0.tgz",
-          "integrity": "sha512-YNRgAJkH2Jky5ySkIqFXTQiaqcAtJyVE+D5lkN6CdtOqrnkLfGYYrEcKuHOJZlp+MwjSwuD3fZuawI+sic/RBw==",
-          "requires": {
-            "@types/hast": "^2.0.0",
-            "comma-separated-tokens": "^2.0.0",
-            "property-information": "^6.0.0",
-            "space-separated-tokens": "^2.0.0",
-            "web-namespaces": "^2.0.0",
-            "zwitch": "^2.0.0"
-          }
-        },
-        "hastscript": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-7.2.0.tgz",
-          "integrity": "sha512-TtYPq24IldU8iKoJQqvZOuhi5CyCQRAbvDOX0x1eW6rsHSxa/1i2CCiptNTotGHJ3VoHRGmqiv6/D3q113ikkw==",
-          "requires": {
-            "@types/hast": "^2.0.0",
-            "comma-separated-tokens": "^2.0.0",
-            "hast-util-parse-selector": "^3.0.0",
-            "property-information": "^6.0.0",
-            "space-separated-tokens": "^2.0.0"
-          }
-        },
-        "html-void-elements": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-2.0.1.tgz",
-          "integrity": "sha512-0quDb7s97CfemeJAnW9wC0hw78MtW7NU3hqtCD75g2vFlDLt36llsYD7uB7SUzojLMP24N5IatXf7ylGXiGG9A=="
-        },
-        "property-information": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.2.0.tgz",
-          "integrity": "sha512-kma4U7AFCTwpqq5twzC1YVIDXSqg6qQK6JN0smOw8fgRy1OkMi0CYSzFmsy6dnqSenamAtj0CyXMUJ1Mf6oROg=="
-        },
-        "space-separated-tokens": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
-          "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="
-        },
-        "unist-util-is": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
-          "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
-          "requires": {
-            "@types/unist": "^2.0.0"
-          }
-        },
-        "unist-util-position": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-4.0.4.tgz",
-          "integrity": "sha512-kUBE91efOWfIVBo8xzh/uZQ7p9ffYRtUbMRZBNFYwf0RK8koUMx6dGUfwylLOKmaT2cs4wSW96QoYUSXAyEtpg==",
-          "requires": {
-            "@types/unist": "^2.0.0"
-          }
-        },
-        "unist-util-stringify-position": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
-          "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
-          "requires": {
-            "@types/unist": "^2.0.0"
-          }
-        },
-        "unist-util-visit": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.2.tgz",
-          "integrity": "sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==",
-          "requires": {
-            "@types/unist": "^2.0.0",
-            "unist-util-is": "^5.0.0",
-            "unist-util-visit-parents": "^5.1.1"
-          }
-        },
-        "unist-util-visit-parents": {
-          "version": "5.1.3",
-          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
-          "integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
-          "requires": {
-            "@types/unist": "^2.0.0",
-            "unist-util-is": "^5.0.0"
-          }
-        },
-        "vfile": {
-          "version": "5.3.7",
-          "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.7.tgz",
-          "integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
-          "requires": {
-            "@types/unist": "^2.0.0",
-            "is-buffer": "^2.0.0",
-            "unist-util-stringify-position": "^3.0.0",
-            "vfile-message": "^3.0.0"
-          }
-        },
-        "vfile-location": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-4.1.0.tgz",
-          "integrity": "sha512-YF23YMyASIIJXpktBa4vIGLJ5Gs88UB/XePgqPmTa7cDA+JeO3yclbpheQYCHjVHBn/yePzrXuygIL+xbvRYHw==",
-          "requires": {
-            "@types/unist": "^2.0.0",
-            "vfile": "^5.0.0"
-          }
-        },
-        "vfile-message": {
-          "version": "3.1.4",
-          "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.4.tgz",
-          "integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
-          "requires": {
-            "@types/unist": "^2.0.0",
-            "unist-util-stringify-position": "^3.0.0"
-          }
-        },
-        "web-namespaces": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
-          "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="
-        },
-        "zwitch": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
-          "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="
         }
       }
     },
     "rehype-sanitize": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-5.0.1.tgz",
-      "integrity": "sha512-da/jIOjq8eYt/1r9GN6GwxIR3gde7OZ+WV8pheu1tL8K0D9KxM2AyMh+UEfke+FfdM3PvGHeYJU0Td5OWa7L5A==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-4.0.0.tgz",
+      "integrity": "sha512-ZCr/iQRr4JeqPjun5i9CHHILVY7i45VnLu1CkkibDrSyFQ7dTLSvw8OIQpHhS4RSh9h/9GidxFw1bRb0LOxIag==",
       "requires": {
-        "@types/hast": "^2.0.0",
-        "hast-util-sanitize": "^4.0.0",
-        "unified": "^10.0.0"
+        "hast-util-sanitize": "^3.0.0"
       }
     },
     "relateurl": {
@@ -51780,14 +49815,12 @@
       "dev": true
     },
     "remark-gfm": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-3.0.1.tgz",
-      "integrity": "sha512-lEFDoi2PICJyNrACFOfDD3JlLkuSbOa5Wd8EPt06HUdptv8Gn0bxYTdbU/XXQ3swAPkEaGxxPN9cbnMHvVu1Ig==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-1.0.0.tgz",
+      "integrity": "sha512-KfexHJCiqvrdBZVbQ6RopMZGwaXz6wFJEfByIuEwGf0arvITHjiKKZ1dpXujjH9KZdm1//XJQwgfnJ3lmXaDPA==",
       "requires": {
-        "@types/mdast": "^3.0.0",
-        "mdast-util-gfm": "^2.0.0",
-        "micromark-extension-gfm": "^2.0.0",
-        "unified": "^10.0.0"
+        "mdast-util-gfm": "^0.1.0",
+        "micromark-extension-gfm": "^0.3.0"
       }
     },
     "remark-mdx": {
@@ -51856,18 +49889,6 @@
             "@babel/helper-plugin-utils": "^7.10.4"
           }
         },
-        "bail": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
-          "integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==",
-          "dev": true
-        },
-        "is-plain-obj": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-          "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
-          "dev": true
-        },
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -51878,12 +49899,6 @@
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-          "dev": true
-        },
-        "trough": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
-          "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
           "dev": true
         },
         "unified": {
@@ -51927,79 +49942,26 @@
       }
     },
     "remark-rehype": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-10.1.0.tgz",
-      "integrity": "sha512-EFmR5zppdBp0WQeDVZ/b66CWJipB2q2VLNFMabzDSGR66Z2fQii83G5gTBbgGEnEEA0QRussvrFHxk1HWGJskw==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-8.1.0.tgz",
+      "integrity": "sha512-EbCu9kHgAxKmW1yEYjx3QafMyGY3q8noUbNUI5xyKbaFP89wbhDrKxyIQNukNYthzjNHZu6J7hwFg7hRm1svYA==",
       "requires": {
-        "@types/hast": "^2.0.0",
-        "@types/mdast": "^3.0.0",
-        "mdast-util-to-hast": "^12.1.0",
-        "unified": "^10.0.0"
+        "mdast-util-to-hast": "^10.2.0"
       },
       "dependencies": {
-        "mdast-util-definitions": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-5.1.2.tgz",
-          "integrity": "sha512-8SVPMuHqlPME/z3gqVwWY4zVXn8lqKv/pAhC57FuJ40ImXyBpmO5ukh98zB2v7Blql2FiHjHv9LVztSIqjY+MA==",
-          "requires": {
-            "@types/mdast": "^3.0.0",
-            "@types/unist": "^2.0.0",
-            "unist-util-visit": "^4.0.0"
-          }
-        },
         "mdast-util-to-hast": {
-          "version": "12.3.0",
-          "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-12.3.0.tgz",
-          "integrity": "sha512-pits93r8PhnIoU4Vy9bjW39M2jJ6/tdHyja9rrot9uujkN7UTU9SDnE6WNJz/IGyQk3XHX6yNNtrBH6cQzm8Hw==",
+          "version": "10.2.0",
+          "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-10.2.0.tgz",
+          "integrity": "sha512-JoPBfJ3gBnHZ18icCwHR50orC9kNH81tiR1gs01D8Q5YpV6adHNO9nKNuFBCJQ941/32PT1a63UF/DitmS3amQ==",
           "requires": {
-            "@types/hast": "^2.0.0",
             "@types/mdast": "^3.0.0",
-            "mdast-util-definitions": "^5.0.0",
-            "micromark-util-sanitize-uri": "^1.1.0",
-            "trim-lines": "^3.0.0",
-            "unist-util-generated": "^2.0.0",
-            "unist-util-position": "^4.0.0",
-            "unist-util-visit": "^4.0.0"
-          }
-        },
-        "unist-util-generated": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-2.0.1.tgz",
-          "integrity": "sha512-qF72kLmPxAw0oN2fwpWIqbXAVyEqUzDHMsbtPvOudIlUzXYFIeQIuxXQCRCFh22B7cixvU0MG7m3MW8FTq/S+A=="
-        },
-        "unist-util-is": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
-          "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
-          "requires": {
-            "@types/unist": "^2.0.0"
-          }
-        },
-        "unist-util-position": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-4.0.4.tgz",
-          "integrity": "sha512-kUBE91efOWfIVBo8xzh/uZQ7p9ffYRtUbMRZBNFYwf0RK8koUMx6dGUfwylLOKmaT2cs4wSW96QoYUSXAyEtpg==",
-          "requires": {
-            "@types/unist": "^2.0.0"
-          }
-        },
-        "unist-util-visit": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.2.tgz",
-          "integrity": "sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==",
-          "requires": {
             "@types/unist": "^2.0.0",
-            "unist-util-is": "^5.0.0",
-            "unist-util-visit-parents": "^5.1.1"
-          }
-        },
-        "unist-util-visit-parents": {
-          "version": "5.1.3",
-          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
-          "integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
-          "requires": {
-            "@types/unist": "^2.0.0",
-            "unist-util-is": "^5.0.0"
+            "mdast-util-definitions": "^4.0.0",
+            "mdurl": "^1.0.0",
+            "unist-builder": "^2.0.0",
+            "unist-util-generated": "^1.0.0",
+            "unist-util-position": "^3.0.0",
+            "unist-util-visit": "^2.0.0"
           }
         }
       }
@@ -52112,8 +50074,7 @@
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
-      "dev": true
+      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w=="
     },
     "require-directory": {
       "version": "2.1.1",
@@ -52284,14 +50245,6 @@
           "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
           "dev": true
         }
-      }
-    },
-    "sade": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
-      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
-      "requires": {
-        "mri": "^1.1.0"
       }
     },
     "safe-buffer": {
@@ -53037,8 +50990,7 @@
     "space-separated-tokens": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz",
-      "integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==",
-      "dev": true
+      "integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA=="
     },
     "spawn-wrap": {
       "version": "2.0.0",
@@ -53560,7 +51512,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.3.0.tgz",
       "integrity": "sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==",
-      "dev": true,
       "requires": {
         "inline-style-parser": "0.1.1"
       }
@@ -54094,11 +52045,6 @@
       "integrity": "sha512-h82ywcYhHK7veeelXrCScdH7HkWfbIT1D/CgYO+nmDarz3SGNssVBMws6jU16Ga60AJCRAvPV6w6RLuNerQqjg==",
       "dev": true
     },
-    "trim-lines": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
-      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="
-    },
     "trim-newlines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
@@ -54113,9 +52059,9 @@
       "dev": true
     },
     "trough": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/trough/-/trough-2.1.0.tgz",
-      "integrity": "sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g=="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
+      "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA=="
     },
     "ts-dedent": {
       "version": "2.2.0",
@@ -54431,47 +52377,16 @@
       "dev": true
     },
     "unified": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
-      "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-9.2.2.tgz",
+      "integrity": "sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ==",
       "requires": {
-        "@types/unist": "^2.0.0",
-        "bail": "^2.0.0",
+        "bail": "^1.0.0",
         "extend": "^3.0.0",
         "is-buffer": "^2.0.0",
-        "is-plain-obj": "^4.0.0",
-        "trough": "^2.0.0",
-        "vfile": "^5.0.0"
-      },
-      "dependencies": {
-        "unist-util-stringify-position": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
-          "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
-          "requires": {
-            "@types/unist": "^2.0.0"
-          }
-        },
-        "vfile": {
-          "version": "5.3.7",
-          "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.7.tgz",
-          "integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
-          "requires": {
-            "@types/unist": "^2.0.0",
-            "is-buffer": "^2.0.0",
-            "unist-util-stringify-position": "^3.0.0",
-            "vfile-message": "^3.0.0"
-          }
-        },
-        "vfile-message": {
-          "version": "3.1.4",
-          "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.4.tgz",
-          "integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
-          "requires": {
-            "@types/unist": "^2.0.0",
-            "unist-util-stringify-position": "^3.0.0"
-          }
-        }
+        "is-plain-obj": "^2.0.0",
+        "trough": "^1.0.0",
+        "vfile": "^4.0.0"
       }
     },
     "union-value": {
@@ -54524,26 +52439,22 @@
     "unist-builder": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-2.0.3.tgz",
-      "integrity": "sha512-f98yt5pnlMWlzP539tPc4grGMsFaQQlP/vM396b00jngsiINumNmsY8rkXjfoi1c6QaM8nQ3vaGDuoKWbe/1Uw==",
-      "dev": true
+      "integrity": "sha512-f98yt5pnlMWlzP539tPc4grGMsFaQQlP/vM396b00jngsiINumNmsY8rkXjfoi1c6QaM8nQ3vaGDuoKWbe/1Uw=="
     },
     "unist-util-generated": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-1.1.6.tgz",
-      "integrity": "sha512-cln2Mm1/CZzN5ttGK7vkoGw+RZ8VcUH6BtGbq98DDtRGquAAOXig1mrBQYelOwMXYS8rK+vZDyyojSjp7JX+Lg==",
-      "dev": true
+      "integrity": "sha512-cln2Mm1/CZzN5ttGK7vkoGw+RZ8VcUH6BtGbq98DDtRGquAAOXig1mrBQYelOwMXYS8rK+vZDyyojSjp7JX+Lg=="
     },
     "unist-util-is": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
-      "integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==",
-      "dev": true
+      "integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg=="
     },
     "unist-util-position": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-3.1.0.tgz",
-      "integrity": "sha512-w+PkwCbYSFw8vpgWD0v7zRCl1FpY3fjDSQ3/N/wNd9Ffa4gPi8+4keqt99N3XW6F99t/mUzp2xAhNmfKWp95QA==",
-      "dev": true
+      "integrity": "sha512-w+PkwCbYSFw8vpgWD0v7zRCl1FpY3fjDSQ3/N/wNd9Ffa4gPi8+4keqt99N3XW6F99t/mUzp2xAhNmfKWp95QA=="
     },
     "unist-util-remove": {
       "version": "2.1.0",
@@ -54567,7 +52478,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
       "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
-      "dev": true,
       "requires": {
         "@types/unist": "^2.0.2"
       }
@@ -54576,7 +52486,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.3.tgz",
       "integrity": "sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==",
-      "dev": true,
       "requires": {
         "@types/unist": "^2.0.0",
         "unist-util-is": "^4.0.0",
@@ -54587,7 +52496,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.1.1.tgz",
       "integrity": "sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==",
-      "dev": true,
       "requires": {
         "@types/unist": "^2.0.0",
         "unist-util-is": "^4.0.0"
@@ -54786,24 +52694,6 @@
       "integrity": "sha512-dsNgbLaTrd6l3MMxTtouOCFw4CBFc/3a+GgYA2YyrJvyQ1u6q4pcu3ktLoUZ/VN/Aw9WsauazbgsgdfVWgAKQg==",
       "dev": true
     },
-    "uvu": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.6.tgz",
-      "integrity": "sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==",
-      "requires": {
-        "dequal": "^2.0.0",
-        "diff": "^5.0.0",
-        "kleur": "^4.0.3",
-        "sade": "^1.7.3"
-      },
-      "dependencies": {
-        "kleur": {
-          "version": "4.1.5",
-          "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
-          "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="
-        }
-      }
-    },
     "v8-to-istanbul": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.0.1.tgz",
@@ -54835,7 +52725,6 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.2.1.tgz",
       "integrity": "sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==",
-      "dev": true,
       "requires": {
         "@types/unist": "^2.0.0",
         "is-buffer": "^2.0.0",
@@ -54846,14 +52735,12 @@
     "vfile-location": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-3.2.0.tgz",
-      "integrity": "sha512-aLEIZKv/oxuCDZ8lkJGhuhztf/BW4M+iHdCwglA/eWc+vtuRFJj8EtgceYFX4LRjOhCAAiNHsKGssC6onJ+jbA==",
-      "dev": true
+      "integrity": "sha512-aLEIZKv/oxuCDZ8lkJGhuhztf/BW4M+iHdCwglA/eWc+vtuRFJj8EtgceYFX4LRjOhCAAiNHsKGssC6onJ+jbA=="
     },
     "vfile-message": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.4.tgz",
       "integrity": "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==",
-      "dev": true,
       "requires": {
         "@types/unist": "^2.0.0",
         "unist-util-stringify-position": "^2.0.0"
@@ -55215,8 +53102,7 @@
     "web-namespaces": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-1.1.4.tgz",
-      "integrity": "sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==",
-      "dev": true
+      "integrity": "sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw=="
     },
     "webidl-conversions": {
       "version": "7.0.0",
@@ -55852,8 +53738,7 @@
     "xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "dev": true
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
       "version": "5.0.8",
@@ -55972,8 +53857,7 @@
     "zwitch": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-1.0.5.tgz",
-      "integrity": "sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==",
-      "dev": true
+      "integrity": "sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw=="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,8 +58,7 @@
         "react-dom": "^17.0.2",
         "tailwindcss": "^3.2.4",
         "ts-jest": "^29.0.3",
-        "typescript": "^4.8.4",
-        "unified": "^9.0.0"
+        "typescript": "^4.8.4"
       },
       "peerDependencies": {
         "react": "^17 || ^18",

--- a/package.json
+++ b/package.json
@@ -77,8 +77,7 @@
     "react-dom": "^17.0.2",
     "tailwindcss": "^3.2.4",
     "ts-jest": "^29.0.3",
-    "typescript": "^4.8.4",
-    "unified": "^9.0.0"
+    "typescript": "^4.8.4"
   },
   "peerDependencies": {
     "react": "^17 || ^18",

--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
     "prettier-check": "prettier --check ."
   },
   "dependencies": {
-    "react-markdown": "^8.0.5",
-    "rehype-raw": "^6.1.1",
-    "rehype-sanitize": "^5.0.1",
-    "remark-gfm": "^3.0.1",
+    "react-markdown": "^6.0.3",
+    "rehype-raw": "^5.0.0",
+    "rehype-sanitize": "^4.0.0",
+    "remark-gfm": "^1.0.0",
     "@lexical/code": "^0.8.0",
     "@lexical/hashtag": "^0.8.0",
     "@lexical/link": "^0.8.0",
@@ -78,7 +78,7 @@
     "tailwindcss": "^3.2.4",
     "ts-jest": "^29.0.3",
     "typescript": "^4.8.4",
-    "unified": "^10.1.2"
+    "unified": "^9.0.0"
   },
   "peerDependencies": {
     "react": "^17 || ^18",

--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -2,7 +2,13 @@ import ReactMarkdown, { PluggableList } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeRaw from "rehype-raw";
 import rehypeSanitize from "rehype-sanitize";
-import { useMemo } from "react";
+
+// The Remark and Rehype plugins to use in conjunction with ReactMarkdown.
+const unifiedPlugins: { remark: PluggableList; rehype: PluggableList } = {
+  remark: [remarkGfm],
+  rehype: [rehypeRaw, rehypeSanitize],
+};
+
 export interface MarkdownProps {
   /** Stringified Github-Flavored Markdown. */
   content: string;
@@ -13,20 +19,11 @@ export interface MarkdownProps {
  * arbitrary HTML. Any HTML will be sanitized according to Rehype's default Schema.
  */
 export function Markdown({ content }: MarkdownProps) {
-  const plugins = useMemo(() => {
-    const unifiedPlugins: { remark: PluggableList; rehype: PluggableList } = {
-      remark: [remarkGfm],
-      rehype: [rehypeRaw, rehypeSanitize],
-    };
-
-    return unifiedPlugins;
-  }, []);
-
   return (
     <ReactMarkdown
       children={content}
-      remarkPlugins={plugins.remark}
-      rehypePlugins={plugins.rehype}
+      remarkPlugins={unifiedPlugins.remark}
+      rehypePlugins={unifiedPlugins.rehype}
     />
   );
 }

--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -1,40 +1,26 @@
-import ReactMarkdown from "react-markdown";
+import ReactMarkdown, { PluggableList } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeRaw from "rehype-raw";
-import rehypeSanitize, { Options } from "rehype-sanitize";
+import rehypeSanitize from "rehype-sanitize";
 import { useMemo } from "react";
-import { PluggableList } from "unified";
-
 export interface MarkdownProps {
   /** Stringified Github-Flavored Markdown. */
   content: string;
-  /** HTML Sanitization Schema for use with Rehype. */
-  sanitizationSchema?: Options;
 }
 
 /**
  * Renders Github-Flavored Markdown from the Knowledge Graph. This Markdown can include
- * arbitrary HTML. Any HTML will be sanitized according to the provided Rehype Schema. If
- * no Schema is provided, Rehype's default will be used.
+ * arbitrary HTML. Any HTML will be sanitized according to Rehype's default Schema.
  */
-export function Markdown({ content, sanitizationSchema }: MarkdownProps) {
+export function Markdown({ content }: MarkdownProps) {
   const plugins = useMemo(() => {
     const unifiedPlugins: { remark: PluggableList; rehype: PluggableList } = {
       remark: [remarkGfm],
-      rehype: [rehypeRaw],
+      rehype: [rehypeRaw, rehypeSanitize],
     };
 
-    if (sanitizationSchema) {
-      unifiedPlugins.rehype.push([
-        rehypeSanitize,
-        { options: sanitizationSchema },
-      ]);
-    } else {
-      unifiedPlugins.rehype.push(rehypeSanitize);
-    }
-
     return unifiedPlugins;
-  }, [sanitizationSchema]);
+  }, []);
 
   return (
     <ReactMarkdown

--- a/tests/components/Markdown.test.tsx
+++ b/tests/components/Markdown.test.tsx
@@ -1,0 +1,112 @@
+import { render, screen } from "@testing-library/react";
+import { Markdown } from "../../src/components/Markdown";
+
+it("wraps normal text in <p> tag", () => {
+  render(<Markdown content="normal text" />);
+  const renderedElement = screen.getByText("normal text");
+
+  expect(renderedElement.tagName).toBe("P");
+});
+
+it("wraps bold text in a <strong> tag", () => {
+  render(<Markdown content="**bold text**" />);
+  const renderedElement = screen.getByText("bold text");
+
+  expect(renderedElement.tagName).toBe("STRONG");
+});
+
+it("wraps italicized text in an <em> tag", () => {
+  render(<Markdown content="*italic text*" />);
+  const renderedElement = screen.getByText("italic text");
+
+  expect(renderedElement.tagName).toBe("EM");
+});
+
+it("wraps striken through text in a <del> tag", () => {
+  render(<Markdown content="~~strikethrough text~~" />);
+  const renderedElement = screen.getByText("strikethrough text");
+
+  expect(renderedElement.tagName).toBe("DEL");
+});
+
+it("renders bolded, striken-through text properly", () => {
+  render(<Markdown content="~~**strikethrough text**~~" />);
+  const renderedElement = screen.getByText("strikethrough text");
+
+  expect(renderedElement.tagName).toBe("STRONG");
+  // eslint-disable-next-line testing-library/no-node-access
+  expect(renderedElement.parentElement?.tagName).toBe("DEL");
+});
+
+it("wraps quotes in a <blockquote> element", () => {
+  render(<Markdown content="> quote" />);
+  const renderedElement = screen.getByText("quote");
+
+  // eslint-disable-next-line testing-library/no-node-access
+  expect(renderedElement.parentElement?.tagName).toBe("BLOCKQUOTE");
+});
+
+describe("renders Headings properly", () => {
+  it("wraps first-level heading in a <h1> tag", () => {
+    render(<Markdown content="# Heading 1" />);
+    const renderedElement = screen.getByText("Heading 1");
+
+    expect(renderedElement.tagName).toBe("H1");
+  });
+
+  it("wraps second-level heading in a <h2> tag", () => {
+    render(<Markdown content="## Heading 2" />);
+    const renderedElement = screen.getByText("Heading 2");
+
+    expect(renderedElement.tagName).toBe("H2");
+  });
+
+  it("wraps third-level heading in a <h3> tag", () => {
+    render(<Markdown content="### Heading 3" />);
+    const renderedElement = screen.getByText("Heading 3");
+
+    expect(renderedElement.tagName).toBe("H3");
+  });
+});
+
+describe("renders code properly", () => {
+  it("wraps in-line code in a <code> tag", () => {
+    render(<Markdown content="`code line`" />);
+    const renderedElement = screen.getByText("code line");
+
+    expect(renderedElement.tagName).toBe("CODE");
+  });
+
+  it("wraps code block in a <code> tag", () => {
+    render(<Markdown content="```code line```" />);
+    const renderedElement = screen.getByText("code line");
+
+    expect(renderedElement.tagName).toBe("CODE");
+  });
+});
+
+describe("renders lists properly", () => {
+  it("renders bullet list properly", () => {
+    const content = "- Item 1\n - Item 2";
+    render(<Markdown content={content} />);
+    const firstElement = screen.getByText("Item 1");
+    const secondElement = screen.getByText("Item 2");
+
+    expect(firstElement.tagName).toBe("LI");
+    expect(secondElement.tagName).toBe("LI");
+    // eslint-disable-next-line testing-library/no-node-access
+    expect(firstElement.parentElement?.tagName).toBe("UL");
+  });
+
+  it("renders number list properly", () => {
+    const content = "1. Item 1\n 2. Item 2";
+    render(<Markdown content={content} />);
+    const firstElement = screen.getByText("Item 1");
+    const secondElement = screen.getByText("Item 2");
+
+    expect(firstElement.tagName).toBe("LI");
+    expect(secondElement.tagName).toBe("LI");
+    // eslint-disable-next-line testing-library/no-node-access
+    expect(firstElement.parentElement?.tagName).toBe("OL");
+  });
+});


### PR DESCRIPTION
Previously, the `Markdown` Component did not work with CommonJS. This is because the versions of `react-markdown`, `remark-gfm`, etc. were ESM-only. In order to have a CommonJS-compatible Component, I needed to downgrade these and other libraries used by `Markdown`.

Initially, the decision was made intentionally to only have an ESM-compatible `Markdown` Component. However, that's proven troublesome for PagesJS users. Now that there is a CommonJS variant of `Markdown`, I was able to add Jest coverage. The Jest tests were essentially ported from the tests KG had in Alpha.

The older version of `rehype-sanitize` does not support user-supplied Schema. That's okay, however. Product and I decided this was not an important feature after all.

TEST=auto,manual

Ran all unit tests. Manually ensured that HTML was getting sanitized properly.