### PR TITLE
Restructure `index.ts` and add `"sideEffects": false` for tree-shaking.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/react-components",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/react-components",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "dependencies": {
         "@lexical/code": "^0.8.0",
         "@lexical/hashtag": "^0.8.0",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "@yext/react-components",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "",
   "author": "slapshot@yext.com",
   "types": "./lib/esm/index.d.ts",
+  "sideEffects": false,
   "exports": {
     ".": {
       "import": "./lib/esm/index.js",

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,8 +1,0 @@
-export * from "./address";
-export * from "./image";
-export { Markdown, MarkdownProps } from "./Markdown";
-export { PinComponent, MapboxMapProps, MapboxMap } from "./MapboxMap";
-export {
-  LexicalRichText,
-  LexicalRichTextProps,
-} from "./richText/LexicalRichText";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,8 @@
-export * from "./components";
+export { Address, AddressProps } from "./components/address";
+export { Image, ImageProps } from "./components/image";
+export { Markdown, MarkdownProps } from "./components/Markdown";
+export { PinComponent, MapboxMapProps, MapboxMap } from "./components/MapboxMap";
+export {
+  LexicalRichText,
+  LexicalRichTextProps,
+} from "./components/richText/LexicalRichText";


### PR DESCRIPTION
This PR makes a couple of changes to improve the tree-shakability of this library. Firstly, we no longer glob everything from `components/index.ts` in `index.ts`. This globbing caused the entire library to be loaded even if you were using just one Component in your application.

The second change is adding `"sideEffects: false` to the `package.json`. You can read more about that attribute here: https://webpack.js.org/guides/tree-shaking/. Basically, this tells Rollup and Webpack that our library can be tree-shaken.

TEST=manual

Created a React application in both PagesJS and CRA that used our Component library. Saw that the bundle size for a page using one Component went from 500 kB to 150 kB. The bundle was tested to make sure the page rendered properly.